### PR TITLE
Remove deprecated Kokkos/Cabana code

### DIFF
--- a/src/binning_cabana.h
+++ b/src/binning_cabana.h
@@ -49,8 +49,7 @@
 
 #ifndef BINNING_CABANA_H
 #define BINNING_CABANA_H
-#include <Cabana_LinkedCellList.hpp>
-#include <Cabana_Slice.hpp>
+#include <Cabana_Core.hpp>
 
 #include <types.h>
 #include <system.h>

--- a/src/cabanamd.cpp
+++ b/src/cabanamd.cpp
@@ -363,7 +363,7 @@ void CabanaMD::check_correctness(int step) {
     printf("Mismatch in current and reference atom counts\n");
   }
 
-  AoSoA xvf_ref( n );
+  AoSoA xvf_ref( "ref", n );
   auto xref = Cabana::slice<Positions>(xvf_ref);
   auto vref = Cabana::slice<Velocities>(xvf_ref);
   auto fref = Cabana::slice<Forces>(xvf_ref);

--- a/src/cabanamd.cpp
+++ b/src/cabanamd.cpp
@@ -94,7 +94,7 @@ void CabanaMD::init(int argc, char* argv[]) {
 #include<modules_force.h>
 #undef FORCE_MODULES_INSTANTIATION
   else comm->error("Invalid ForceType");
-  for(std::size_t line = 0; line < input->force_coeff_lines.dimension_0(); line++) {
+  for(std::size_t line = 0; line < input->force_coeff_lines.extent(0); line++) {
     force->init_coeff(neigh_cutoff,
                       input->input_data.words[input->force_coeff_lines(line)]);
   }

--- a/src/cabanamd.h
+++ b/src/cabanamd.h
@@ -47,6 +47,7 @@
 //  Questions? Contact Christian R. Trott (crtrott@sandia.gov)
 //************************************************************************
 
+#include <Kokkos_Core.hpp>
 #include <Cabana_Core.hpp>
 
 #include <types.h>

--- a/src/cabanamd.h
+++ b/src/cabanamd.h
@@ -47,9 +47,9 @@
 //  Questions? Contact Christian R. Trott (crtrott@sandia.gov)
 //************************************************************************
 
-#include <Cabana_Slice.hpp>
-#include <types.h>
+#include <Cabana_Core.hpp>
 
+#include <types.h>
 #include<system.h>
 #include<integrator_nve.h>
 #include<force.h>

--- a/src/comm_mpi.h
+++ b/src/comm_mpi.h
@@ -51,8 +51,9 @@
 #define COMM_MPI_H
 
 #include "mpi.h"
-#include <Cabana_Distributor.hpp>
-#include <Cabana_Halo.hpp>
+
+#include <Cabana_Core.hpp>
+
 #include <types.h>
 #include <system.h>
 

--- a/src/comm_mpi.h
+++ b/src/comm_mpi.h
@@ -52,6 +52,7 @@
 
 #include "mpi.h"
 
+#include <Kokkos_Core.hpp>
 #include <Cabana_Core.hpp>
 
 #include <types.h>

--- a/src/force_types/force_lj_cabana_neigh.h
+++ b/src/force_types/force_lj_cabana_neigh.h
@@ -86,8 +86,7 @@
 
 #ifndef FORCE_LJ_CABANA_NEIGH_H
 #define FORCE_LJ_CABANA_NEIGH_H
-#include <Cabana_NeighborList.hpp>
-#include <Cabana_Slice.hpp>
+#include <Cabana_Core.hpp>
 
 #include<force.h>
 #include<types.h>

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -418,7 +418,7 @@ void Input::check_lammps_command(int line) {
   }
   if(strcmp(input_data.words[line][0],"pair_coeff")==0) {
     known = true;
-    int n_coeff_lines = force_coeff_lines.dimension_0();
+    int n_coeff_lines = force_coeff_lines.extent(0);
     Kokkos::resize(force_coeff_lines,n_coeff_lines+1);
     force_coeff_lines( n_coeff_lines) = line;
     n_coeff_lines++;

--- a/src/input.h
+++ b/src/input.h
@@ -47,12 +47,13 @@
 //  Questions? Contact Christian R. Trott (crtrott@sandia.gov)
 //************************************************************************
 
-#include <Cabana_Slice.hpp>
+#include <Cabana_Core.hpp>
 
-#include <vector>
 #include <types.h>
 #include <system.h>
 #include <comm_mpi.h>
+
+#include <vector>
 
 class ItemizedFile {
 public:

--- a/src/input.h
+++ b/src/input.h
@@ -47,6 +47,7 @@
 //  Questions? Contact Christian R. Trott (crtrott@sandia.gov)
 //************************************************************************
 
+#include <Kokkos_Core.hpp>
 #include <Cabana_Core.hpp>
 
 #include <types.h>

--- a/src/integrator_nve.h
+++ b/src/integrator_nve.h
@@ -49,6 +49,7 @@
 
 #ifndef INTEGRATOR_NVE_H
 #define INTEGRATOR_NVE_H
+#include <Kokkos_Core.hpp>
 #include <Cabana_Core.hpp>
 
 #include <types.h>

--- a/src/integrator_nve.h
+++ b/src/integrator_nve.h
@@ -49,7 +49,7 @@
 
 #ifndef INTEGRATOR_NVE_H
 #define INTEGRATOR_NVE_H
-#include <Cabana_AoSoA.hpp>
+#include <Cabana_Core.hpp>
 
 #include <types.h>
 #include <system.h>

--- a/src/property_kine.h
+++ b/src/property_kine.h
@@ -47,6 +47,7 @@
 //  Questions? Contact Christian R. Trott (crtrott@sandia.gov)
 //************************************************************************
 
+#include <Kokkos_Core.hpp>
 #include <Cabana_Core.hpp>
 
 #include <types.h>

--- a/src/property_kine.h
+++ b/src/property_kine.h
@@ -47,8 +47,7 @@
 //  Questions? Contact Christian R. Trott (crtrott@sandia.gov)
 //************************************************************************
 
-
-#include <Cabana_Slice.hpp>
+#include <Cabana_Core.hpp>
 
 #include <types.h>
 #include <system.h>

--- a/src/property_temperature.h
+++ b/src/property_temperature.h
@@ -47,6 +47,7 @@
 //  Questions? Contact Christian R. Trott (crtrott@sandia.gov)
 //************************************************************************
 
+#include <Kokkos_Core.hpp>
 #include <Cabana_Core.hpp>
 
 #include <types.h>

--- a/src/property_temperature.h
+++ b/src/property_temperature.h
@@ -47,7 +47,7 @@
 //  Questions? Contact Christian R. Trott (crtrott@sandia.gov)
 //************************************************************************
 
-#include <Cabana_Slice.hpp>
+#include <Cabana_Core.hpp>
 
 #include <types.h>
 #include <system.h>

--- a/src/read_data.h
+++ b/src/read_data.h
@@ -39,6 +39,8 @@
 
    Please read the accompanying LICENSE_MINIMD file.
 ---------------------------------------------------------------------- */
+#include <Cabana_Core.hpp>
+
 #include <comm_mpi.h>
 #include <types.h>
 

--- a/src/read_data.h
+++ b/src/read_data.h
@@ -39,12 +39,13 @@
 
    Please read the accompanying LICENSE_MINIMD file.
 ---------------------------------------------------------------------- */
+#include <comm_mpi.h>
+#include <types.h>
+
 #include <cstring>
 #include <string>
-#include <comm_mpi.h>
 #include <iostream>
 #include <fstream>
-#include <types.h>
 
 using namespace std;
 

--- a/src/system.h
+++ b/src/system.h
@@ -49,7 +49,8 @@
 
 #ifndef SYSTEM_H
 #define SYSTEM_H
-#include <Cabana_Slice.hpp>
+#include <Cabana_Core.hpp>
+
 #include<types.h>
 #include <string>
 

--- a/src/system.h
+++ b/src/system.h
@@ -49,6 +49,7 @@
 
 #ifndef SYSTEM_H
 #define SYSTEM_H
+#include <Kokkos_Core.hpp>
 #include <Cabana_Core.hpp>
 
 #include<types.h>

--- a/src/types.h
+++ b/src/types.h
@@ -50,9 +50,7 @@
 #ifndef TYPES_H
 #define TYPES_H
 #include<Kokkos_Core.hpp>
-#include<Cabana_AoSoA.hpp>
-#include<Cabana_VerletList.hpp>
-#include<CabanaCore_config.hpp>
+#include <Cabana_Core.hpp>
 
 #define VECLEN 16
 

--- a/src/types.h
+++ b/src/types.h
@@ -49,7 +49,7 @@
 
 #ifndef TYPES_H
 #define TYPES_H
-#include<Kokkos_Core.hpp>
+#include <Kokkos_Core.hpp>
 #include <Cabana_Core.hpp>
 
 #define VECLEN 16


### PR DESCRIPTION
With these changes CabanaMD runs without recently removed deprecated Cabana code and with Kokkos disable_deprecated_code

Closes #18