### PR TITLE
Fix read_data for multi-node, add masses

### DIFF
--- a/src/read_data.h
+++ b/src/read_data.h
@@ -47,38 +47,47 @@
 #include <iostream>
 #include <string>
 
-using namespace std;
-
-string read_lammps_parse_keyword( ifstream &file )
+void skip_empty( std::ifstream &file, std::string &line )
 {
-    // TODO: error checking. Look at setup.cpp
-    // proc 0 reads upto non-blank line plus 1 following line
-    // eof is set to 1 if any read hits end-of-file
-    string line;
-    string keyword = "";
+    // skip blank lines
+    while ( 1 )
+    {
+        std::getline( file, line );
+        if ( !line.empty() )
+            break;
+    }
+}
+
+std::string read_lammps_parse_keyword( std::ifstream &file )
+{
+    // Read up to first non-blank line plus 1 following
+    std::string line;
+    std::string keyword = "";
     while ( 1 )
     {
         // exit if end-of-file is encountered
         if ( file.eof() )
             break;
-        getline( file, line );
-        // ignore anything after # by getting substring till # (takes care of
-        // comment lines too)
+        std::getline( file, line );
+        // get substring prior to # (ignore comments)
         line = line.substr( 0, line.find( '#' ) );
-        // for non blank lines, skip leading whitespaces and read word
+        // for non-blank lines, skip leading whitespaces and read word
         std::size_t pos = line.find_first_not_of( " \r\t\n" );
-        if ( pos != string::npos )
+        if ( pos != std::string::npos )
         {
             keyword = line;
-            if ( ( keyword.compare( "Atoms " ) == 0 ) ||
-                 ( keyword.compare( "Velocities " ) == 0 ) ||
-                 ( keyword.compare( "Atoms" ) == 0 ) ||
-                 ( keyword.compare( "Velocities" ) == 0 ) )
+            int end = keyword.find_last_not_of( " " ) + 1;
+            if ( end < line.length() )
+                keyword.erase( end );
+            if ( ( keyword.compare( "Atoms" ) == 0 ) ||
+                 ( keyword.compare( "Velocities" ) == 0 ) ||
+                 ( keyword.compare( "Masses" ) == 0 ) ||
+                 ( keyword.compare( "Pair Coeffs" ) == 0 ) )
                 return keyword;
             else
             {
-                printf( "ERROR: Unknown identifier in data file: %s\n",
-                        keyword.data() );
+                std::cout << "ERROR: Unknown identifier in data file: "
+                          << keyword.data() << std::endl;
                 return keyword;
             }
         }
@@ -88,21 +97,22 @@ string read_lammps_parse_keyword( ifstream &file )
     return keyword;
 }
 
-void read_lammps_header( ifstream &file, System *s )
+int read_lammps_header( std::ifstream &file, System *s )
 {
-    string line;
+    std::string line;
     // skip 1st line of file
-    if ( !getline( file, line ) )
-        printf(
-            "ERROR: could not read line from file. Please check for a valid "
-            "file and ensure that file path is less than 32 characters\n" );
+    if ( !std::getline( file, line ) )
+        std::cout
+            << "ERROR: could not read line from file. Please check for a valid "
+               "file and ensure that file path is less than 32 characters"
+            << std::endl;
     while ( 1 )
     {
 
-        getline( file, line );
+        std::getline( file, line );
         // skip blank lines
         std::size_t pos = line.find_first_not_of( " \r\t\n" );
-        if ( pos == string::npos )
+        if ( pos == std::string::npos )
             continue;
 
         // ignore anything after # by getting substring till # (takes care of
@@ -114,33 +124,33 @@ void read_lammps_header( ifstream &file, System *s )
         const char *temp = line.data(); // convert to C-string for sscanf
                                         // utility
         // search line for header keyword and set corresponding variable
-        if ( line.find( "atoms" ) != string::npos )
+        if ( line.find( "atoms" ) != std::string::npos )
         {
-            sscanf( temp, "%i", &natoms );
+            std::sscanf( temp, "%i", &natoms );
             s->N = natoms;
         }
-        else if ( line.find( "atom types" ) != string::npos )
+        else if ( line.find( "atom types" ) != std::string::npos )
         {
-            sscanf( temp, "%i", &ntypes );
+            std::sscanf( temp, "%i", &ntypes );
             s->ntypes = ntypes;
         }
-        else if ( line.find( "xlo xhi" ) != string::npos )
+        else if ( line.find( "xlo xhi" ) != std::string::npos )
         {
-            sscanf( temp, "%lg %lg", &xlo, &xhi );
+            std::sscanf( temp, "%lg %lg", &xlo, &xhi );
             s->domain_lo_x = xlo;
             s->domain_hi_x = xhi;
             s->domain_x = xhi - xlo;
         }
-        else if ( line.find( "ylo yhi" ) != string::npos )
+        else if ( line.find( "ylo yhi" ) != std::string::npos )
         {
-            sscanf( temp, "%lg %lg", &ylo, &yhi );
+            std::sscanf( temp, "%lg %lg", &ylo, &yhi );
             s->domain_lo_y = ylo;
             s->domain_hi_y = yhi;
             s->domain_y = yhi - ylo;
         }
-        else if ( line.find( "zlo zhi" ) != string::npos )
+        else if ( line.find( "zlo zhi" ) != std::string::npos )
         {
-            sscanf( temp, "%lg %lg", &zlo, &zhi );
+            std::sscanf( temp, "%lg %lg", &zlo, &zhi );
             s->domain_lo_z = zlo;
             s->domain_hi_z = zhi;
             s->domain_z = zhi - zlo;
@@ -149,32 +159,27 @@ void read_lammps_header( ifstream &file, System *s )
     }
 }
 
-void read_lammps_atoms( ifstream &file, System *s )
+void read_lammps_atoms( std::ifstream &file, System *s )
 {
-    string line;
+    std::string line;
     auto x = Cabana::slice<Positions>( s->xvf );
     auto id = Cabana::slice<IDs>( s->xvf );
     auto type = Cabana::slice<Types>( s->xvf );
     auto q = Cabana::slice<Charges>( s->xvf );
 
-    // skip any empty lines before reading in data
-    while ( 1 )
-    {
-        getline( file, line );
-        if ( !line.empty() )
-            break;
-    }
+    skip_empty( file, line );
 
     T_INT id_tmp, type_tmp;
     T_FLOAT x_tmp, y_tmp, z_tmp, q_tmp;
     T_INT counter = 0;
     for ( int n = 0; n < s->N; n++ )
     {
+        // TODO: error if atom_style doesn't match data
         const char *temp = line.data();
         if ( s->atom_style == "atomic" )
         {
-            sscanf( temp, "%i %i %lg %lg %lg", &id_tmp, &type_tmp, &x_tmp,
-                    &y_tmp, &z_tmp );
+            std::sscanf( temp, "%i %i %lg %lg %lg", &id_tmp, &type_tmp, &x_tmp,
+                         &y_tmp, &z_tmp );
             if ( ( x_tmp >= s->sub_domain_lo_x ) &&
                  ( y_tmp >= s->sub_domain_lo_y ) &&
                  ( z_tmp >= s->sub_domain_lo_z ) &&
@@ -190,12 +195,12 @@ void read_lammps_atoms( ifstream &file, System *s )
                 q( n ) = 0;
                 counter++;
             }
-            getline( file, line );
+            std::getline( file, line );
         }
         if ( s->atom_style == "charge" )
         {
-            sscanf( temp, "%i %i %lg %lg %lg %lg", &id_tmp, &type_tmp, &q_tmp,
-                    &x_tmp, &y_tmp, &z_tmp );
+            std::sscanf( temp, "%i %i %lg %lg %lg %lg", &id_tmp, &type_tmp,
+                         &q_tmp, &x_tmp, &y_tmp, &z_tmp );
             if ( ( x_tmp >= s->sub_domain_lo_x ) &&
                  ( y_tmp >= s->sub_domain_lo_y ) &&
                  ( z_tmp >= s->sub_domain_lo_z ) &&
@@ -213,88 +218,123 @@ void read_lammps_atoms( ifstream &file, System *s )
             }
             // getline pushed to the end of loop because line already stores the
             // 1st non-blank line after exiting while loop
-            getline( file, line );
+            std::getline( file, line );
         }
     }
     s->N_local = counter;
-    s->N = counter;
 }
 
-void read_lammps_velocities( ifstream &file, System *s )
+void read_lammps_velocities( std::ifstream &file, System *s )
 {
-    string line;
+    std::string line;
     auto v = Cabana::slice<Velocities>( s->xvf );
 
-    // skip any empty lines before reading in data
-    while ( 1 )
-    {
-        getline( file, line );
-        if ( !line.empty() )
-            break;
-    }
+    skip_empty( file, line );
 
     T_INT id_tmp;
     T_FLOAT vx_tmp, vy_tmp, vz_tmp;
     for ( int n = 0; n < s->N; n++ )
     {
         const char *temp = line.data();
-        sscanf( temp, "%i %lg %lg %lg", &id_tmp, &vx_tmp, &vy_tmp, &vz_tmp );
+        std::sscanf( temp, "%i %lg %lg %lg", &id_tmp, &vx_tmp, &vy_tmp,
+                     &vz_tmp );
         v( n, 0 ) = vx_tmp;
         v( n, 1 ) = vy_tmp;
         v( n, 2 ) = vz_tmp;
-        getline( file, line );
+        std::getline( file, line );
     }
+}
+
+void read_lammps_masses( std::ifstream &file, System *s )
+{
+    std::string line;
+    s->mass = t_mass( "System::mass", s->ntypes );
+
+    skip_empty( file, line );
+
+    T_INT type_tmp;
+    T_FLOAT m_tmp;
+    for ( int n = 0; n < s->ntypes; n++ )
+    {
+        const char *temp = line.data();
+        std::sscanf( temp, "%i %lg", &type_tmp, &m_tmp );
+        Kokkos::View<T_V_FLOAT> mass_one( s->mass, type_tmp - 1 );
+        Kokkos::deep_copy( mass_one, m_tmp );
+        std::getline( file, line );
+    }
+}
+
+void read_lammps_pair( std::ifstream &file, System *s )
+{
+    // Parse through pair_coeff lines to avoid error, but ignore values
+    std::string line;
+    skip_empty( file, line );
+
+    for ( int n = 0; n < s->ntypes; n++ )
+        std::getline( file, line );
 }
 
 void read_lammps_data_file( const char *filename, System *s, Comm *comm )
 {
 
-    string keyword;
-    ifstream file( filename );
-    // TODO: error checking bad files
-    // read header information
+    int atomflag = 0;
+    std::string keyword;
+    std::ifstream file( filename );
+
     read_lammps_header( file, s );
 
+    // TODO: this won't scale
     s->resize( s->N );
 
     // perform domain decomposition and get access to subdomains
     comm->create_domain_decomposition();
 
-    // check that exiting string is a valid section keyword
+    // check that the next string is a valid section keyword
     keyword = read_lammps_parse_keyword( file );
+    while ( keyword.length() )
+    {
+        if ( keyword.compare( "Atoms" ) == 0 )
+        {
+            read_lammps_atoms( file, s );
+            atomflag = 1;
+        }
+        else if ( keyword.compare( "Velocities" ) == 0 )
+        {
+            if ( atomflag == 0 )
+                std::cout << "ERROR: Must read Atoms before Velocities"
+                          << std::endl;
 
-    // read atom information
-    read_lammps_atoms( file, s );
-    // TODO: catch this error: printf("Must read Atoms before Velocities\n");
+            read_lammps_velocities( file, s );
+        }
+        else if ( keyword.compare( "Masses" ) == 0 )
+        {
+            read_lammps_masses( file, s );
+        }
+        else if ( keyword.compare( "Pair Coeffs" ) == 0 )
+        {
+            std::cout << "WARNING: Ignoring potential parameters in data file. "
+                         "CabanaMD only reads pair_coeff in the input file."
+                      << std::endl;
+            read_lammps_pair( file, s );
+        }
+        else
+        {
+            std::cout << "ERROR: Unknown identifier in data file: " << keyword
+                      << std::endl;
+        }
 
-    keyword = read_lammps_parse_keyword( file );
-    // read velocities
-    if ( keyword.compare( "Velocities" ) == 0 )
-        read_lammps_velocities( file, s );
-
-// TODO: read masses from data file
-/*else if(strcmp(keyword, "Masses") == 0) {
-  fgets(line, MAXLINE, fp);
-
-  #if PRECISION==1
-          sscanf(line, "%i %g", &tmp, &atom.mass);
-  #else
-          sscanf(line, "%i %lg", &tmp, &atom.mass);
-  #endif
-}
-*/
-#ifdef CabanaMD_ENABLE_MPI
-    int me;
-    MPI_Comm_rank( MPI_COMM_WORLD, &me );
+        keyword = read_lammps_parse_keyword( file );
+    }
 
     // check that correct # of atoms were created
-    int natoms;
-    MPI_Allreduce( s->N_local, &natoms, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD );
+    int natoms = s->N_local;
+    comm->reduce_int( &natoms, 1 );
 
     if ( natoms != s->N )
     {
-        if ( me == 0 && system->do_print )
-            printf( "ERROR: Created incorrect # of atoms\n" );
+        if ( s->do_print )
+            std::cout << "ERROR: Created incorrect # of atoms" << std::endl;
     }
-#endif
+
+    s->resize( s->N_local );
 }


### PR DESCRIPTION
The previous version only worked with one MPI rank and did not handle masses or potential coefficients (still ignored, but not an error).

Closes #11 