### PR TITLE
Optional pair_style nnp exit

### DIFF
--- a/src/cabanamd.cpp
+++ b/src/cabanamd.cpp
@@ -68,17 +68,32 @@ void CabanaMD::init( int argc, char *argv[] )
 {
 
     if ( system->do_print )
+    {
         Kokkos::DefaultExecutionSpace::print_configuration( std::cout );
-
+    }
     // Parse command line arguments
     input->read_command_line_args( argc, argv );
     if ( system->do_print )
+    {
         printf( "Read command line arguments\n" );
-
+    }
     // Read input file
     input->read_file();
     if ( system->do_print )
+    {
         printf( "Read input file\n" );
+    }
+    // Check that the requested pair_style was compiled
+#ifndef CabanaMD_ENABLE_NNP
+    if ( input->force_type == FORCE_NNP )
+    {
+        if ( system->do_print )
+        {
+            std::cout << "NNP requested, but not compiled!" << std::endl;
+        }
+        std::exit( 1 );
+    }
+#endif
     T_X_FLOAT neigh_cutoff = input->force_cutoff + input->neighbor_skin;
 
     // Create Integrator class: NVE ensemble
@@ -118,9 +133,13 @@ void CabanaMD::init( int argc, char *argv[] )
 
     // Create atoms - from LAMMPS data file or create FCC/SC lattice
     if ( system->N == 0 && input->read_data_flag == true )
+    {
         read_lammps_data_file( input->lammps_data_file, system, comm );
+    }
     else if ( system->N == 0 )
+    {
         input->create_lattice( comm );
+    }
 
     // Exchange atoms across MPI ranks
     comm->exchange();
@@ -176,10 +195,13 @@ void CabanaMD::init( int argc, char *argv[] )
     }
 
     if ( input->dumpbinaryflag )
+    {
         dump_binary( step );
-
+    }
     if ( input->correctnessflag )
+    {
         check_correctness( step );
+    }
 }
 
 void CabanaMD::run( int nsteps )


### PR DESCRIPTION
Since the NNP compilation is optional (mainly due to the external library dependency), this ensures NNP was compiled if requested by the user in the input file