### PR TITLE
Use Kokkos/Cabana CMake targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ addons:
 before_script:
   - sudo ln -s /usr/bin/ccache /usr/lib/ccache/clang++
   - ccache -z
-  - KOKKOS_OPTS=( --with-hwloc=/usr --gcc-toolchain=/usr)
-  - for i in ${BACKENDS}; do KOKKOS_OPTS+=( --with-${i,,[A-Z]} ); done
+  - KOKKOS_OPTS=( -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DKokkos_ENABLE_HWLOC=ON )
+  - for i in ${BACKENDS}; do KOKKOS_OPTS+=( -DKokkos_ENABLE_${i^^}=ON ); done
   - for i in ${BACKENDS}; do CABANA_OPTS+=( -DCabana_ENABLE_${i}=ON ); done
   - for i in ${BACKENDS}; do CABANAMD_OPTS+=( -DCabanaMD_ENABLE_${i}=ON ); done
     # LD_LIBRARY_PATH workaround for libomp: https://github.com/travis-ci/travis-ci/issues/8613
@@ -27,9 +27,8 @@ before_script:
   - pushd $HOME/build
   - git clone --depth=1 https://github.com/kokkos/kokkos.git &&
     pushd kokkos && mkdir build && pushd build &&
-    ../generate_makefile.bash --prefix=$HOME/kokkos ${KOKKOS_OPTS[@]} &&
-    make -j2 &&
-    make install &&
+    cmake -DCMAKE_INSTALL_PREFIX=$HOME/kokkos ${KOKKOS_OPTS[@]} .. &&
+    make -j2 && make install &&
     popd && popd
   - pwd
   - git clone --depth=1 https://github.com/ECP-copa/Cabana.git
@@ -41,7 +40,7 @@ before_script:
           -DCabana_ENABLE_MPI=ON
           -DCabana_ENABLE_TESTING=OFF -DCabana_ENABLE_EXAMPLES=OFF
           -DCabana_ENABLE_PERFORMANCE_TESTING=OFF .. &&
-    make -k -j2 VERBOSE=1 && make install &&
+    make -k -j2 && make install &&
     popd && popd
   - if [[ ${NNP} ]]; then
       git clone --depth=1 https://github.com/CompPhysVienna/n2p2.git &&
@@ -66,8 +65,7 @@ env:
 
 script:
   - mkdir build && pushd build &&
-    cmake -DKOKKOS_DIR=$HOME/kokkos
-          -DCABANA_DIR=$HOME/Cabana
+    cmake -DCMAKE_PREFIX_PATH="$HOME/Cabana;$HOME/kokkos"
           -DCabanaMD_ENABLE_Serial=OFF
           -DCabanaMD_ENABLE_NNP=${NNP}
           -DN2P2_DIR=$HOME/build/n2p2

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ addons:
       - g++-6
 
 before_script:
-  - sudo ln -s /usr/bin/ccache /usr/lib/ccache/clang++
   - ccache -z
   - KOKKOS_OPTS=( -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DKokkos_ENABLE_HWLOC=ON )
   - for i in ${BACKENDS}; do KOKKOS_OPTS+=( -DKokkos_ENABLE_${i^^}=ON ); done
@@ -28,19 +27,20 @@ before_script:
   - git clone --depth=1 https://github.com/kokkos/kokkos.git &&
     pushd kokkos && mkdir build && pushd build &&
     cmake -DCMAKE_INSTALL_PREFIX=$HOME/kokkos ${KOKKOS_OPTS[@]} .. &&
-    make -j2 && make install &&
+    make -j2 VERBOSE=1 && make install &&
     popd && popd
   - pwd
   - git clone --depth=1 https://github.com/ECP-copa/Cabana.git
   - pushd Cabana && mkdir build && pushd build &&
-    cmake -DCMAKE_PREFIX_PATH=$HOME/kokkos
+    cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          -DCMAKE_PREFIX_PATH=$HOME/kokkos
           -DCMAKE_INSTALL_PREFIX=$HOME/Cabana
           -DCabana_ENABLE_Serial=OFF
           ${CABANA_OPTS[@]}
           -DCabana_ENABLE_MPI=ON
           -DCabana_ENABLE_TESTING=OFF -DCabana_ENABLE_EXAMPLES=OFF
           -DCabana_ENABLE_PERFORMANCE_TESTING=OFF .. &&
-    make -k -j2 && make install &&
+    make -k -j2 VERBOSE=1 && make install &&
     popd && popd
   - if [[ ${NNP} ]]; then
       git clone --depth=1 https://github.com/CompPhysVienna/n2p2.git &&
@@ -65,7 +65,8 @@ env:
 
 script:
   - mkdir build && pushd build &&
-    cmake -DCMAKE_PREFIX_PATH="$HOME/Cabana;$HOME/kokkos"
+    cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          -DCMAKE_PREFIX_PATH="$HOME/Cabana;$HOME/kokkos"
           -DCabanaMD_ENABLE_Serial=OFF
           -DCabanaMD_ENABLE_NNP=${NNP}
           -DN2P2_DIR=$HOME/build/n2p2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,36 +20,18 @@ find_package(Cabana REQUIRED)
 find_package(MPI REQUIRED)
 
 option(CabanaMD_ENABLE_Serial "Build CabanaMD with Serial support" ON)
-if( CabanaMD_ENABLE_Serial )
-  if( NOT Kokkos_ENABLE_SERIAL )
-    message( FATAL_ERROR "Requested SERIAL, but not enabled in Kokkos!" )
-  endif()
-  add_definitions(-DCabanaMD_ENABLE_Serial=ON)
-endif()
-
-option(CabanaMD_ENABLE_Pthread "Build CabanaMD with Pthread support" OFF)
-if( CabanaMD_ENABLE_Pthread )
-  if( NOT Kokkos_ENABLE_PTHREAD )
-    message( FATAL_ERROR "Requested PTHREAD, but not enabled in Kokkos!" )
-  endif()
-  add_definitions(-DCabanaMD_ENABLE_Pthread=ON)
-endif()
-
+option(CabanaMD_ENABLE_Threads "Build CabanaMD with Threads support" OFF)
 option(CabanaMD_ENABLE_OpenMP "Build CabanaMD with OpenMP support" OFF)
-if( CabanaMD_ENABLE_OpenMP )
-  if( NOT Kokkos_ENABLE_OPENMP )
-    message( FATAL_ERROR "Requested OPENMP, but not enabled in Kokkos!" )
-  endif()
-  add_definitions(-DCabanaMD_ENABLE_OpenMP=ON)
-endif()
-
 option(CabanaMD_ENABLE_Cuda "Build CabanaMD with Cuda support" OFF)
-if( CabanaMD_ENABLE_Cuda )
-  if( NOT Kokkos_ENABLE_CUDA )
-    message( FATAL_ERROR "Requested CUDA, but not enabled in Kokkos!" )
+
+set(CABANAMD_SUPPORTED_DEVICES Serial Threads OpenMP Cuda)
+foreach(_device ${CABANAMD_SUPPORTED_DEVICES})
+  if(CabanaMD_ENABLE_${_device})
+    string(TOUPPER ${_device} _uppercase_device)
+    kokkos_check( DEVICES ${_uppercase_device} )
+    add_definitions(-DCabanaMD_ENABLE_${_device}=ON)
   endif()
-  add_definitions(-DCabanaMD_ENABLE_Cuda=ON)
-endif()
+endforeach()
 
 ##---------------------------------------------------------------------------##
 # Set up optional libraries
@@ -65,7 +47,6 @@ endif()
 ##---------------------------------------------------------------------------##
 ## Print the revision number to stdout
 ##---------------------------------------------------------------------------##
-
 FIND_PACKAGE(Git)
 IF(GIT_FOUND AND IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/.git)
     EXECUTE_PROCESS(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,15 +51,9 @@ if( CabanaMD_ENABLE_Cuda )
   endif(CUDA_FOUND)
 endif()
 
+find_package(Kokkos REQUIRED)
+find_package(Cabana REQUIRED)
 find_package(MPI REQUIRED)
-
-if(NOT DEFINED CABANA_DIR)
-  set(CABANA_DIR ~/install/cabana/)
-endif()
-
-if(NOT DEFINED KOKKOS_DIR)
-  set(KOKKOS_DIR ~/install/kokkos/)
-endif()
 
 option(CabanaMD_ENABLE_NNP "Build CabanaMD with neural network potential (and n2p2 libnnp)" OFF)
 if( CabanaMD_ENABLE_NNP )
@@ -95,20 +89,14 @@ else()
   file(GLOB SOURCES src/*.cpp src/force_types/force_lj*.cpp)
 endif()
 
-include_directories(SYSTEM ${KOKKOS_DIR}/include)
-link_directories(${KOKKOS_DIR}/lib)
-include_directories(${CABANA_DIR}/include)
-link_directories(${CABANA_DIR}/lib64)
-link_directories(${CABANA_DIR}/lib)
 include_directories(${N2P2_DIR}/include)
 link_directories(${N2P2_DIR}/lib)
 
 add_executable(CabanaMD ${SOURCES})
 
+target_link_libraries(CabanaMD Cabana::cabanacore Kokkos::kokkos MPI::MPI_CXX dl hwloc)
 if(CabanaMD_ENABLE_NNP)
-  target_link_libraries(CabanaMD cabanacore kokkos dl hwloc MPI::MPI_CXX nnp)
-else()
-  target_link_libraries(CabanaMD cabanacore kokkos dl hwloc MPI::MPI_CXX)
+  target_link_libraries(CabanaMD nnp)
 endif()
 
 install(TARGETS CabanaMD DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,47 +14,46 @@ include(GNUInstallDirs)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 ##---------------------------------------------------------------------------##
-# Set up main options
+# Set up main options (inherit from Kokkos and Cabana CMake)
 ##---------------------------------------------------------------------------##
+find_package(Cabana REQUIRED)
+find_package(MPI REQUIRED)
+
 option(CabanaMD_ENABLE_Serial "Build CabanaMD with Serial support" ON)
 if( CabanaMD_ENABLE_Serial )
+  if( NOT Kokkos_ENABLE_SERIAL )
+    message( FATAL_ERROR "Requested SERIAL, but not enabled in Kokkos!" )
+  endif()
   add_definitions(-DCabanaMD_ENABLE_Serial=ON)
 endif()
 
-#option(CabanaMD_ENABLE_Pthread "Build CabanaMD with Pthread support" OFF)
-#if( CabanaMD_ENABLE_Pthread )
-#  add_definitions(-DCabanaMD_ENABLE_Pthread=ON)
-#  find_package(Threads)
-#endif()
+option(CabanaMD_ENABLE_Pthread "Build CabanaMD with Pthread support" OFF)
+if( CabanaMD_ENABLE_Pthread )
+  if( NOT Kokkos_ENABLE_PTHREAD )
+    message( FATAL_ERROR "Requested PTHREAD, but not enabled in Kokkos!" )
+  endif()
+  add_definitions(-DCabanaMD_ENABLE_Pthread=ON)
+endif()
 
 option(CabanaMD_ENABLE_OpenMP "Build CabanaMD with OpenMP support" OFF)
 if( CabanaMD_ENABLE_OpenMP )
-  add_definitions(-DCabanaMD_ENABLE_OpenMP=ON)
-  find_package(OpenMP)
-  if (OPENMP_FOUND)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+  if( NOT Kokkos_ENABLE_OPENMP )
+    message( FATAL_ERROR "Requested OPENMP, but not enabled in Kokkos!" )
   endif()
+  add_definitions(-DCabanaMD_ENABLE_OpenMP=ON)
 endif()
 
 option(CabanaMD_ENABLE_Cuda "Build CabanaMD with Cuda support" OFF)
 if( CabanaMD_ENABLE_Cuda )
+  if( NOT Kokkos_ENABLE_CUDA )
+    message( FATAL_ERROR "Requested CUDA, but not enabled in Kokkos!" )
+  endif()
   add_definitions(-DCabanaMD_ENABLE_Cuda=ON)
-  find_package(CUDA)
-  if (CUDA_FOUND)
-    message("Found CUDA")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --expt-extended-lambda -g")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored")
-  else()
-    message( FATAL_ERROR "Requested CUDA but cant find it!")
-  endif(CUDA_FOUND)
 endif()
 
-find_package(Kokkos REQUIRED)
-find_package(Cabana REQUIRED)
-find_package(MPI REQUIRED)
-
+##---------------------------------------------------------------------------##
+# Set up optional libraries
+##---------------------------------------------------------------------------##
 option(CabanaMD_ENABLE_NNP "Build CabanaMD with neural network potential (and n2p2 libnnp)" OFF)
 if( CabanaMD_ENABLE_NNP )
   add_definitions(-DCabanaMD_ENABLE_NNP=ON)
@@ -83,7 +82,7 @@ MESSAGE(STATUS "CabanaMD Revision = '${CabanaMD_GIT_COMMIT_HASH}'")
 ## Build CabanaMD
 ##---------------------------------------------------------------------------##
 include_directories(src src/force_types)
-if(CabanaMD_ENABLE_NNP)
+if( CabanaMD_ENABLE_NNP )
   file(GLOB SOURCES src/*.cpp src/force_types/*.cpp)
 else()
   file(GLOB SOURCES src/*.cpp src/force_types/force_lj*.cpp)
@@ -95,7 +94,7 @@ link_directories(${N2P2_DIR}/lib)
 add_executable(CabanaMD ${SOURCES})
 
 target_link_libraries(CabanaMD Cabana::cabanacore Kokkos::kokkos MPI::MPI_CXX dl hwloc)
-if(CabanaMD_ENABLE_NNP)
+if( CabanaMD_ENABLE_NNP )
   target_link_libraries(CabanaMD nnp)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ https://github.com/ECP-copa/Cabana
 
 
 ExaMiniMD is a proxy app and research vehicle for 
-MD using Kokkos:
+MD using the Kokkos performance portability library
+("KokkosMD"):
 https://github.com/ECP-copa/ExaMiniMD
-
+https://github.com/kokkos/kokkos
 
 
 # Build instructions
@@ -22,7 +23,7 @@ CabanaMD has the following dependencies:
 |---------- | ------- |--------  |------- |
 |CMake      | 3.9+    | Yes      | Build system
 |MPI        | GPU Aware if CUDA Enabled | Yes | Message Passing Interface
-|Kokkos     | 2.7.0   | Yes      | Provides portable on-node parallelism
+|Kokkos     | 3.0     | Yes      | Provides portable on-node parallelism
 |Cabana     | 0.3-dev | Yes      | Performance portable particle algorithms
 |libnnp     | 1.0.0   | No       | Neural network potential utilities
 
@@ -36,16 +37,15 @@ MPI is required (`-D Cabana_ENABLE_MPI=ON`)
 After building Kokkos and Cabana for CPU:
 ```
 # Change directories as needed
-export KOKKOS_INSTALL_DIR=$HOME/install/kokkos
-export CABANA_INSTALL_DIR=$HOME/install/cabana
+export KOKKOS_INSTALL_DIR=$HOME/kokkos
+export CABANA_INSTALL_DIR=$HOME/Cabana
 
 cd ./CabanaMD
 mkdir build
 cd build
 pwd
 cmake \
-    -D KOKKOS_DIR=$KOKKOS_INSTALL_DIR \
-    -D CABANA_DIR=$CABANA_INSTALL_DIR \
+    -D CMAKE_PREFIX_PATH="$KOKKOS_INSTALL_DIR;$CABANA_INSTALL_DIR" \
     -D CabanaMD_ENABLE_Serial=OFF \
     -D CabanaMD_ENABLE_OpenMP=ON \
     -D CabanaMD_ENABLE_Cuda=OFF \
@@ -63,8 +63,7 @@ the GPU build is identical to that above except the options passed to CMake:
 ```
 cmake \
     -D CMAKE_CXX_COMPILER=$KOKKOS_SRC_DIR/bin/nvcc_wrapper \
-    -D KOKKOS_DIR=$KOKKOS_INSTALL_DIR \
-    -D CABANA_DIR=$CABANA_INSTALL_DIR \
+    -D CMAKE_PREFIX_PATH="$KOKKOS_INSTALL_DIR;$CABANA_INSTALL_DIR" \
     -D CabanaMD_ENABLE_Serial=OFF \
     -D CabanaMD_ENABLE_OpenMP=OFF \
     -D CabanaMD_ENABLE_Cuda=ON \

--- a/src/types.h
+++ b/src/types.h
@@ -162,7 +162,9 @@ using ExecutionSpace = Kokkos::Cuda;
 using MemorySpace = Kokkos::HostSpace;
 #ifdef CabanaMD_ENABLE_Serial
 using ExecutionSpace = Kokkos::Serial;
-#else // CabanaMD_ENABLE_OpenMP
+#elif defined( CabanaMD_ENABLE_Threads )
+using ExecutionSpace = Kokkos::Threads;
+#elif defined( CabanaMD_ENABLE_OpenMP )
 using ExecutionSpace = Kokkos::OpenMP;
 #endif
 #endif


### PR DESCRIPTION
Update CMake and Travis to use recent Kokkos 3.0 update to CMake and Cabana CMake targets (ECP-copa/Cabana#165)