### PR TITLE
Use cmakedefine variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ foreach(_device ${CABANAMD_SUPPORTED_DEVICES})
   if(CabanaMD_ENABLE_${_device})
     string(TOUPPER ${_device} _uppercase_device)
     kokkos_check( DEVICES ${_uppercase_device} )
-    add_definitions(-DCabanaMD_ENABLE_${_device}=ON)
   endif()
 endforeach()
 
@@ -39,11 +38,8 @@ endforeach()
 ##---------------------------------------------------------------------------##
 
 option(CabanaMD_ENABLE_NNP "Build CabanaMD with neural network potential (and n2p2 libnnp)" OFF)
-if( CabanaMD_ENABLE_NNP )
-  add_definitions(-DCabanaMD_ENABLE_NNP=ON)
-endif()
 if(NOT DEFINED N2P2_DIR)
-  set(N2P2_DIR ~/install/n2p2/)
+  set(N2P2_DIR ~/n2p2/)
 endif()
 
 ##---------------------------------------------------------------------------##

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,19 +18,23 @@ endif()
 list(APPEND SOURCES ${FORCE_TYPES})
 
 install(FILES ${HEADERS_PUBLIC} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CabanaMD_config.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 #------------------------------------------------------------
 
 add_library(CabanaMD ${SOURCES})
 
 # Sources linking against CabanaMD will implicitly include these directories:
-target_include_directories(CabanaMD PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/force_types)
+target_include_directories(CabanaMD PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+                                    ${CMAKE_CURRENT_SOURCE_DIR}/force_types
+                                    ${CMAKE_INSTALL_INCLUDEDIR}
+                                    ${CMAKE_CURRENT_BINARY_DIR})
 
 #------------------------------------------------------------
 
 target_link_libraries(CabanaMD Cabana::cabanacore Kokkos::kokkos MPI::MPI_CXX dl hwloc)
 
-if(CabanaMD_ENABLE_NNP)
+if(CabanaMD_ENABLE_NNP AND N2P2_DIR)
   target_include_directories(CabanaMD PUBLIC ${N2P2_DIR}/include)
   find_library(N2P2_LIB nnp PATHS ${N2P2_DIR}/lib NO_DEFAULT_PATH)
   target_link_libraries(CabanaMD ${N2P2_LIB})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,8 +27,8 @@ add_library(CabanaMD ${SOURCES})
 # Sources linking against CabanaMD will implicitly include these directories:
 target_include_directories(CabanaMD PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
                                     ${CMAKE_CURRENT_SOURCE_DIR}/force_types
-                                    ${CMAKE_INSTALL_INCLUDEDIR}
-                                    ${CMAKE_CURRENT_BINARY_DIR})
+                                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+                                    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 #------------------------------------------------------------
 
@@ -41,4 +41,3 @@ if(CabanaMD_ENABLE_NNP AND N2P2_DIR)
 endif()
 
 install(TARGETS CabanaMD DESTINATION lib)
-

--- a/src/CabanaMD_config.hpp.cmakein
+++ b/src/CabanaMD_config.hpp.cmakein
@@ -5,7 +5,7 @@
 #define CabanaMD_GIT_COMMIT_HASH "@CabanaMD_GIT_COMMIT_HASH@"
 
 #cmakedefine CabanaMD_ENABLE_Serial
-#cmakefefile CabanaMD_ENABLE_Threads
+#cmakedefine CabanaMD_ENABLE_Threads
 #cmakedefine CabanaMD_ENABLE_OpenMP
 #cmakedefine CabanaMD_ENABLE_Cuda
 #cmakedefine CabanaMD_ENABLE_NNP

--- a/src/cabanamd.h
+++ b/src/cabanamd.h
@@ -54,6 +54,8 @@
 #include <system.h>
 #include <types.h>
 
+#include <CabanaMD_config.hpp>
+
 #include <Cabana_Core.hpp>
 #include <Kokkos_Core.hpp>
 

--- a/src/modules_force.h
+++ b/src/modules_force.h
@@ -46,6 +46,8 @@
 //
 //************************************************************************
 
+#include <CabanaMD_config.hpp>
+
 // Include Module header files for force
 #include <force_lj_cabana_neigh.h>
 

--- a/src/types.h
+++ b/src/types.h
@@ -49,6 +49,8 @@
 #ifndef TYPES_H
 #define TYPES_H
 
+#include <CabanaMD_config.hpp>
+
 #include <Cabana_Core.hpp>
 #include <Kokkos_Core.hpp>
 


### PR DESCRIPTION
`#cmakedefine` was added in #31, but those variables were still being manually added with `add_definitions`

Also, checking that `N2P2_DIR` exists because of cmake unused variable warnings