### PR TITLE
Update NNP kernels

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,11 @@ if(CabanaMD_ENABLE_NNP)
     endif()
   endif()
   message( STATUS "Using vector length: ${CabanaMD_VECTORLENGTH_NNP} (NNP)" )
+
+  if(NOT CabanaMD_MAXSYMMFUNC_NNP)
+    set(CabanaMD_MAXSYMMFUNC_NNP 30)
+  endif()
+  message( STATUS "Maximum symmetry functions: ${CabanaMD_MAXSYMMFUNC_NNP} (NNP)" )
 endif()
 
 #------------------------------------------------------------

--- a/src/CabanaMD_config.hpp.cmakein
+++ b/src/CabanaMD_config.hpp.cmakein
@@ -20,5 +20,6 @@
 #cmakedefine CabanaMD_LAYOUT_NNP_1AoSoA
 #cmakedefine CabanaMD_LAYOUT_NNP_3AoSoA
 #cmakedefine CabanaMD_VECTORLENGTH_NNP @CabanaMD_VECTORLENGTH_NNP@
+#cmakedefine CabanaMD_MAXSYMMFUNC_NNP @CabanaMD_MAXSYMMFUNC_NNP@
 
 #endif

--- a/src/force_types/force_nnp_cabana_neigh.h
+++ b/src/force_types/force_nnp_cabana_neigh.h
@@ -30,6 +30,15 @@ class ForceNNP : public Force<t_System, t_Neighbor>
     int N_local, ntypes;
     int step;
 
+    typedef typename t_System::t_x t_x;
+    // Must be atomic
+    typedef typename t_System::t_f::atomic_access_slice t_f;
+    typedef typename t_System::t_type t_type;
+
+    typedef typename t_System_NNP::t_G t_G;
+    typedef typename t_System_NNP::t_dEdG t_dEdG;
+    typedef typename t_System_NNP::t_E t_E;
+
     typedef typename t_Neighbor::t_neigh_list t_neigh_list;
 
     // NNP-specific System class for AoSoAs

--- a/src/force_types/force_nnp_cabana_neigh_impl.h
+++ b/src/force_types/force_nnp_cabana_neigh_impl.h
@@ -69,20 +69,34 @@ template <class t_System, class t_System_NNP, class t_Neighbor,
 void ForceNNP<t_System, t_System_NNP, t_Neighbor, t_neigh_parallel,
               t_angle_parallel>::compute( t_System *s, t_Neighbor *neighbor )
 {
+    N_local = s->N_local;
+
     auto neigh_list = neighbor->get();
 
-    system_nnp->resize( s->N_local );
+    system_nnp->resize( N_local );
+
+    s->slice_force();
+    auto x = s->x;
+    // Atomic force slice
+    auto f_a = s->f;
+    auto type = s->type;
+
+    system_nnp->slice_G();
+    system_nnp->slice_dEdG();
+    system_nnp->slice_E();
+    auto G = system_nnp->G;
+    auto dEdG = system_nnp->dEdG;
+    auto E = system_nnp->E;
 
     Kokkos::deep_copy( d_numSFperElem, h_numSFperElem );
-    mode->calculateSymmetryFunctionGroups<t_System, t_System_NNP, t_neigh_list,
+    mode->calculateSymmetryFunctionGroups<t_x, t_type, t_G, t_neigh_list,
                                           t_neigh_parallel, t_angle_parallel>(
-        s, system_nnp, neigh_list );
-    mode->calculateAtomicNeuralNetworks<t_System, t_System_NNP, t_neigh_list,
-                                        t_neigh_parallel, t_angle_parallel>(
-        s, system_nnp, d_numSFperElem );
-    mode->calculateForces<t_System, t_System_NNP, t_neigh_list,
-                          t_neigh_parallel, t_angle_parallel>( s, system_nnp,
-                                                               neigh_list );
+        x, type, G, neigh_list, N_local );
+    mode->calculateAtomicNeuralNetworks<t_type, t_G, t_dEdG, t_E>(
+        type, G, dEdG, E, d_numSFperElem, N_local );
+    mode->calculateForces<t_x, t_f, t_type, t_dEdG, t_neigh_list,
+                          t_neigh_parallel, t_angle_parallel>(
+        x, f_a, type, dEdG, neigh_list, N_local );
 }
 
 template <class t_System, class t_System_NNP, class t_Neighbor,

--- a/src/force_types/nnp_element.cpp
+++ b/src/force_types/nnp_element.cpp
@@ -41,7 +41,7 @@ Element::~Element() {}
 void Element::addSymmetryFunction( string const &parameters,
                                    vector<string> elementStrings, int attype,
                                    t_SF SF, double convLength,
-                                   int ( &countertotal )[2] )
+                                   h_t_int h_numSFperElem )
 {
     vector<string> args = nnp::split( nnp::reduce( parameters ) );
     size_t type = (size_t)atoi( args.at( 1 ).c_str() );
@@ -58,8 +58,8 @@ void Element::addSymmetryFunction( string const &parameters,
             if ( strcmp( elementStrings[i].c_str(), estring ) == 0 )
                 el = i;
         }
-        SF( attype, countertotal[attype], 0 ) = el;   // ec
-        SF( attype, countertotal[attype], 1 ) = type; // type
+        SF( attype, h_numSFperElem( attype ), 0 ) = el;   // ec
+        SF( attype, h_numSFperElem( attype ), 1 ) = type; // type
 
         estring = splitLine.at( 2 ).c_str();
         // np.where element symbol == symbol encountered during parsing
@@ -68,20 +68,20 @@ void Element::addSymmetryFunction( string const &parameters,
             if ( strcmp( elementStrings[i].c_str(), estring ) == 0 )
                 el = i;
         }
-        SF( attype, countertotal[attype], 2 ) = el; // e1
+        SF( attype, h_numSFperElem( attype ), 2 ) = el; // e1
         // set e2 to arbit high number for ease in creating groups
-        SF( attype, countertotal[attype], 3 ) = 100000; // e2
+        SF( attype, h_numSFperElem( attype ), 3 ) = 100000; // e2
 
-        SF( attype, countertotal[attype], 4 ) =
+        SF( attype, h_numSFperElem( attype ), 4 ) =
             atof( splitLine.at( 3 ).c_str() ) /
             ( convLength * convLength ); // eta
-        SF( attype, countertotal[attype], 8 ) =
+        SF( attype, h_numSFperElem( attype ), 8 ) =
             atof( splitLine.at( 4 ).c_str() ) * convLength; // rs
-        SF( attype, countertotal[attype], 7 ) =
+        SF( attype, h_numSFperElem( attype ), 7 ) =
             atof( splitLine.at( 5 ).c_str() ) * convLength; // rc
 
-        SF( attype, countertotal[attype], 13 ) = countertotal[attype];
-        countertotal[attype]++;
+        SF( attype, h_numSFperElem( attype ), 13 ) = h_numSFperElem( attype );
+        h_numSFperElem( attype )++;
     }
 
     else if ( type == 3 )
@@ -95,8 +95,8 @@ void Element::addSymmetryFunction( string const &parameters,
             if ( strcmp( elementStrings[i].c_str(), estring ) == 0 )
                 el = i;
         }
-        SF( attype, countertotal[attype], 0 ) = el;   // ec
-        SF( attype, countertotal[attype], 1 ) = type; // type
+        SF( attype, h_numSFperElem( attype ), 0 ) = el;   // ec
+        SF( attype, h_numSFperElem( attype ), 1 ) = type; // type
 
         estring = splitLine.at( 2 ).c_str();
         // np.where element symbol == symbol encountered during parsing
@@ -105,7 +105,7 @@ void Element::addSymmetryFunction( string const &parameters,
             if ( strcmp( elementStrings[i].c_str(), estring ) == 0 )
                 el = i;
         }
-        SF( attype, countertotal[attype], 2 ) = el; // e1
+        SF( attype, h_numSFperElem( attype ), 2 ) = el; // e1
 
         estring = splitLine.at( 3 ).c_str();
         // np.where element symbol == symbol encountered during parsing
@@ -115,41 +115,41 @@ void Element::addSymmetryFunction( string const &parameters,
                 el = i;
         }
 
-        SF( attype, countertotal[attype], 3 ) = el; // e2
-        SF( attype, countertotal[attype], 4 ) =
+        SF( attype, h_numSFperElem( attype ), 3 ) = el; // e2
+        SF( attype, h_numSFperElem( attype ), 4 ) =
             atof( splitLine.at( 4 ).c_str() ) /
             ( convLength * convLength ); // eta
-        SF( attype, countertotal[attype], 5 ) =
+        SF( attype, h_numSFperElem( attype ), 5 ) =
             atof( splitLine.at( 5 ).c_str() ); // lambda
-        SF( attype, countertotal[attype], 6 ) =
+        SF( attype, h_numSFperElem( attype ), 6 ) =
             atof( splitLine.at( 6 ).c_str() ); // zeta
-        SF( attype, countertotal[attype], 7 ) =
+        SF( attype, h_numSFperElem( attype ), 7 ) =
             atof( splitLine.at( 7 ).c_str() ) * convLength; // rc
         // Shift parameter is optional.
         if ( splitLine.size() > 8 )
-            SF( attype, countertotal[attype], 8 ) =
+            SF( attype, h_numSFperElem( attype ), 8 ) =
                 atof( splitLine.at( 8 ).c_str() ) * convLength; // rs
 
-        T_INT e1 = SF( attype, countertotal[attype], 2 );
-        T_INT e2 = SF( attype, countertotal[attype], 3 );
+        T_INT e1 = SF( attype, h_numSFperElem( attype ), 2 );
+        T_INT e2 = SF( attype, h_numSFperElem( attype ), 3 );
         if ( e1 > e2 )
         {
             size_t tmp = e1;
             e1 = e2;
             e2 = tmp;
         }
-        SF( attype, countertotal[attype], 2 ) = e1;
-        SF( attype, countertotal[attype], 3 ) = e2;
+        SF( attype, h_numSFperElem( attype ), 2 ) = e1;
+        SF( attype, h_numSFperElem( attype ), 3 ) = e2;
 
-        T_FLOAT zeta = SF( attype, countertotal[attype], 6 );
+        T_FLOAT zeta = SF( attype, h_numSFperElem( attype ), 6 );
         T_INT zetaInt = round( zeta );
         if ( fabs( zeta - zetaInt ) <= numeric_limits<double>::min() )
-            SF( attype, countertotal[attype], 9 ) = 1;
+            SF( attype, h_numSFperElem( attype ), 9 ) = 1;
         else
-            SF( attype, countertotal[attype], 9 ) = 0;
+            SF( attype, h_numSFperElem( attype ), 9 ) = 0;
 
-        SF( attype, countertotal[attype], 13 ) = countertotal[attype];
-        countertotal[attype]++;
+        SF( attype, h_numSFperElem( attype ), 13 ) = h_numSFperElem( attype );
+        h_numSFperElem( attype )++;
     }
     // TODO: Add this later
     else if ( type == 9 )
@@ -169,7 +169,7 @@ void Element::addSymmetryFunction( string const &parameters,
     return;
 }
 
-void Element::sortSymmetryFunctions( t_SF SF, h_t_mass h_numSFperElem,
+void Element::sortSymmetryFunctions( t_SF SF, h_t_int h_numSFperElem,
                                      int attype )
 {
     int size = h_numSFperElem( attype );
@@ -267,13 +267,13 @@ bool Element::compareSF( t_SF SF, int attype, int index1, int index2 )
 
 vector<string>
 Element::infoSymmetryFunctionParameters( t_SF SF, int attype,
-                                         int ( &countertotal )[2] ) const
+                                         h_t_int h_numSFperElem ) const
 {
     vector<string> v;
     string pushstring = "";
     int index;
     float writestring;
-    for ( int i = 0; i < countertotal[attype]; ++i )
+    for ( int i = 0; i < h_numSFperElem( attype ); ++i )
     {
         index = SF( attype, i, 13 );
         // TODO: improve function
@@ -292,11 +292,11 @@ Element::infoSymmetryFunctionParameters( t_SF SF, int attype,
 vector<string>
 Element::infoSymmetryFunctionScaling( ScalingType scalingType, t_SF SF,
                                       t_SFscaling SFscaling, int attype,
-                                      int ( &countertotal )[2] ) const
+                                      h_t_int h_numSFperElem ) const
 {
     vector<string> v;
     int index;
-    for ( int k = 0; k < countertotal[attype]; ++k )
+    for ( int k = 0; k < h_numSFperElem( attype ); ++k )
     {
         index = SF( attype, k, 13 );
         v.push_back( scalingLine( scalingType, SFscaling, attype, index ) );
@@ -306,14 +306,14 @@ Element::infoSymmetryFunctionScaling( ScalingType scalingType, t_SF SF,
 
 void Element::setupSymmetryFunctionGroups( t_SF SF,
                                            t_SFGmemberlist SFGmemberlist,
-                                           int attype, int ( &countertotal )[2],
+                                           int attype, h_t_int h_numSFperElem,
                                            int ( &countergtotal )[2],
                                            int maxSFperElem )
 {
     int *countergR = new int[countergtotal[attype]];
     int *countergAN = new int[countergtotal[attype]];
     int SFindex;
-    for ( int k = 0; k < countertotal[attype]; ++k )
+    for ( int k = 0; k < h_numSFperElem( attype ); ++k )
     {
         bool createNewGroup = true;
         SFindex = SF( attype, k, 13 );
@@ -405,9 +405,9 @@ Element::infoSymmetryFunctionGroups( t_SF SF, t_SFGmemberlist SFGmemberlist,
 
 void Element::setCutoffFunction( CutoffFunction::CutoffType const cutoffType,
                                  double const cutoffAlpha, t_SF SF, int attype,
-                                 int ( &countertotal )[2] )
+                                 h_t_int h_numSFperElem )
 {
-    for ( int k = 0; k < countertotal[attype]; ++k )
+    for ( int k = 0; k < h_numSFperElem( attype ); ++k )
     {
         SF( attype, k, 10 ) = cutoffType;
         SF( attype, k, 11 ) = cutoffAlpha;
@@ -418,17 +418,17 @@ void Element::setCutoffFunction( CutoffFunction::CutoffType const cutoffType,
 void Element::setScaling( ScalingType scalingType,
                           vector<string> const &statisticsLine, double Smin,
                           double Smax, t_SF SF, t_SFscaling SFscaling,
-                          int attype, int ( &countertotal )[2] ) const
+                          int attype, h_t_int h_numSFperElem ) const
 {
     int index;
-    for ( int k = 0; k < countertotal[attype]; ++k )
+    for ( int k = 0; k < h_numSFperElem( attype ); ++k )
     {
         index = SF( attype, k, 13 );
         setScalingType( scalingType, statisticsLine.at( k ), Smin, Smax,
                         SFscaling, attype, index );
     }
     // TODO: groups
-    // for (int k = 0; k < countertotal[attype]; ++k)
+    // for (int k = 0; k < h_numSFperElem(attype); ++k)
     //    setScalingFactors(SF,attype,k);
 
     return;
@@ -454,22 +454,22 @@ size_t Element::getMinNeighbors( int attype, t_SF SF, int nSF ) const
 }
 
 double Element::getMinCutoffRadius( t_SF SF, int attype,
-                                    int ( &countertotal )[2] ) const
+                                    h_t_int h_numSFperElem ) const
 {
     double minCutoffRadius = numeric_limits<double>::max();
 
-    for ( int k = 0; k < countertotal[attype]; ++k )
+    for ( int k = 0; k < h_numSFperElem( attype ); ++k )
         minCutoffRadius = min( SF( attype, k, 7 ), minCutoffRadius );
 
     return minCutoffRadius;
 }
 
 double Element::getMaxCutoffRadius( t_SF SF, int attype,
-                                    int ( &countertotal )[2] ) const
+                                    h_t_int h_numSFperElem ) const
 {
     double maxCutoffRadius = 0.0;
 
-    for ( int k = 0; k < countertotal[attype]; ++k )
+    for ( int k = 0; k < h_numSFperElem( attype ); ++k )
         maxCutoffRadius = max( SF( attype, k, 7 ), maxCutoffRadius );
 
     return maxCutoffRadius;

--- a/src/force_types/nnp_element.cpp
+++ b/src/force_types/nnp_element.cpp
@@ -307,17 +307,17 @@ Element::infoSymmetryFunctionScaling( ScalingType scalingType, t_SF SF,
 void Element::setupSymmetryFunctionGroups( t_SF SF,
                                            t_SFGmemberlist SFGmemberlist,
                                            int attype, h_t_int h_numSFperElem,
-                                           int ( &countergtotal )[2],
+                                           h_t_int h_numSFGperElem,
                                            int maxSFperElem )
 {
-    int *countergR = new int[countergtotal[attype]];
-    int *countergAN = new int[countergtotal[attype]];
+    h_t_int h_numGR( "RadialCounter", h_numSFGperElem.extent( 0 ) );
+    h_t_int h_numGA( "AngularCounter", h_numSFGperElem.extent( 0 ) );
     int SFindex;
     for ( int k = 0; k < h_numSFperElem( attype ); ++k )
     {
         bool createNewGroup = true;
         SFindex = SF( attype, k, 13 );
-        for ( int l = 0; l < countergtotal[attype]; ++l )
+        for ( int l = 0; l < h_numSFGperElem( attype ); ++l )
         {
             if ( ( SF( attype, SFindex, 0 ) ==
                    SF( attype, SFGmemberlist( attype, l, 0 ),
@@ -341,16 +341,16 @@ void Element::setupSymmetryFunctionGroups( t_SF SF,
                 createNewGroup = false;
                 if ( SF( attype, SFindex, 1 ) == 2 )
                 {
-                    SFGmemberlist( attype, l, countergR[l] ) = SFindex;
-                    countergR[l]++;
+                    SFGmemberlist( attype, l, h_numGR( l ) ) = SFindex;
+                    h_numGR( l )++;
                     SFGmemberlist( attype, l, maxSFperElem )++;
                     break;
                 }
 
                 else if ( SF( attype, SFindex, 1 ) == 3 )
                 {
-                    SFGmemberlist( attype, l, countergAN[l] ) = SFindex;
-                    countergAN[l]++;
+                    SFGmemberlist( attype, l, h_numGA( l ) ) = SFindex;
+                    h_numGA( l )++;
                     SFGmemberlist( attype, l, maxSFperElem )++;
                     break;
                 }
@@ -359,20 +359,20 @@ void Element::setupSymmetryFunctionGroups( t_SF SF,
 
         if ( createNewGroup )
         {
-            int l = countergtotal[attype];
-            countergtotal[attype]++;
+            int l = h_numSFGperElem( attype );
+            h_numSFGperElem( attype )++;
             if ( SF( attype, SFindex, 1 ) == 2 )
             {
-                countergR[l] = 0;
-                SFGmemberlist( attype, l, countergR[l] ) = SFindex;
-                countergR[l]++;
+                h_numGR( l ) = 0;
+                SFGmemberlist( attype, l, h_numGR( l ) ) = SFindex;
+                h_numGR( l )++;
                 SFGmemberlist( attype, l, maxSFperElem )++;
             }
             else if ( SF( attype, SFindex, 1 ) == 3 )
             {
-                countergAN[l] = 0;
-                SFGmemberlist( attype, l, countergAN[l] ) = SFindex;
-                countergAN[l]++;
+                h_numGA( l ) = 0;
+                SFGmemberlist( attype, l, h_numGA( l ) ) = SFindex;
+                h_numGA( l )++;
                 SFGmemberlist( attype, l, maxSFperElem )++;
             }
         }
@@ -383,12 +383,12 @@ void Element::setupSymmetryFunctionGroups( t_SF SF,
 
 vector<string>
 Element::infoSymmetryFunctionGroups( t_SF SF, t_SFGmemberlist SFGmemberlist,
-                                     int attype,
-                                     int ( &countergtotal )[2] ) const
+                                     int attype, h_t_int h_numSFGperElem ) const
 {
     vector<string> v;
     string pushstring = "";
-    for ( int groupIndex = 0; groupIndex < countergtotal[attype]; ++groupIndex )
+    for ( int groupIndex = 0; groupIndex < h_numSFGperElem( attype );
+          ++groupIndex )
     {
         // TODO: improve function
         for ( int j = 0; j < 8; ++j )

--- a/src/force_types/nnp_element.cpp
+++ b/src/force_types/nnp_element.cpp
@@ -307,7 +307,8 @@ Element::infoSymmetryFunctionScaling( ScalingType scalingType, t_SF SF,
 void Element::setupSymmetryFunctionGroups( t_SF SF,
                                            t_SFGmemberlist SFGmemberlist,
                                            int attype, int ( &countertotal )[2],
-                                           int ( &countergtotal )[2] )
+                                           int ( &countergtotal )[2],
+                                           int maxSFperElem )
 {
     int *countergR = new int[countergtotal[attype]];
     int *countergAN = new int[countergtotal[attype]];
@@ -342,7 +343,7 @@ void Element::setupSymmetryFunctionGroups( t_SF SF,
                 {
                     SFGmemberlist( attype, l, countergR[l] ) = SFindex;
                     countergR[l]++;
-                    SFGmemberlist( attype, l, MAX_SF )++;
+                    SFGmemberlist( attype, l, maxSFperElem )++;
                     break;
                 }
 
@@ -350,7 +351,7 @@ void Element::setupSymmetryFunctionGroups( t_SF SF,
                 {
                     SFGmemberlist( attype, l, countergAN[l] ) = SFindex;
                     countergAN[l]++;
-                    SFGmemberlist( attype, l, MAX_SF )++;
+                    SFGmemberlist( attype, l, maxSFperElem )++;
                     break;
                 }
             }
@@ -365,14 +366,14 @@ void Element::setupSymmetryFunctionGroups( t_SF SF,
                 countergR[l] = 0;
                 SFGmemberlist( attype, l, countergR[l] ) = SFindex;
                 countergR[l]++;
-                SFGmemberlist( attype, l, MAX_SF )++;
+                SFGmemberlist( attype, l, maxSFperElem )++;
             }
             else if ( SF( attype, SFindex, 1 ) == 3 )
             {
                 countergAN[l] = 0;
                 SFGmemberlist( attype, l, countergAN[l] ) = SFindex;
                 countergAN[l]++;
-                SFGmemberlist( attype, l, MAX_SF )++;
+                SFGmemberlist( attype, l, maxSFperElem )++;
             }
         }
     }

--- a/src/force_types/nnp_element.cpp
+++ b/src/force_types/nnp_element.cpp
@@ -52,7 +52,6 @@ void Element::addSymmetryFunction( string const &parameters,
     if ( type == 2 )
     {
         estring = splitLine.at( 0 ).c_str();
-        // np.where element symbol == symbol encountered during parsing
         for ( size_t i = 0; i < elementStrings.size(); ++i )
         {
             if ( strcmp( elementStrings[i].c_str(), estring ) == 0 )
@@ -62,7 +61,6 @@ void Element::addSymmetryFunction( string const &parameters,
         SF( attype, h_numSFperElem( attype ), 1 ) = type; // type
 
         estring = splitLine.at( 2 ).c_str();
-        // np.where element symbol == symbol encountered during parsing
         for ( size_t i = 0; i < elementStrings.size(); ++i )
         {
             if ( strcmp( elementStrings[i].c_str(), estring ) == 0 )
@@ -89,7 +87,6 @@ void Element::addSymmetryFunction( string const &parameters,
         if ( type != (size_t)atoi( splitLine.at( 1 ).c_str() ) )
             throw runtime_error( "ERROR: Incorrect symmetry function type.\n" );
         estring = splitLine.at( 0 ).c_str();
-        // np.where element symbol == symbol encountered during parsing
         for ( size_t i = 0; i < elementStrings.size(); ++i )
         {
             if ( strcmp( elementStrings[i].c_str(), estring ) == 0 )
@@ -99,7 +96,6 @@ void Element::addSymmetryFunction( string const &parameters,
         SF( attype, h_numSFperElem( attype ), 1 ) = type; // type
 
         estring = splitLine.at( 2 ).c_str();
-        // np.where element symbol == symbol encountered during parsing
         for ( size_t i = 0; i < elementStrings.size(); ++i )
         {
             if ( strcmp( elementStrings[i].c_str(), estring ) == 0 )
@@ -108,7 +104,6 @@ void Element::addSymmetryFunction( string const &parameters,
         SF( attype, h_numSFperElem( attype ), 2 ) = el; // e1
 
         estring = splitLine.at( 3 ).c_str();
-        // np.where element symbol == symbol encountered during parsing
         for ( size_t i = 0; i < elementStrings.size(); ++i )
         {
             if ( strcmp( elementStrings[i].c_str(), estring ) == 0 )
@@ -173,9 +168,9 @@ void Element::sortSymmetryFunctions( t_SF SF, h_t_int h_numSFperElem,
                                      int attype )
 {
     int size = h_numSFperElem( attype );
-    int *SFvector = new int[size];
+    h_t_int h_SFsort( "SortSort", size );
     for ( int i = 0; i < size; ++i )
-        SFvector[i] = i;
+        h_SFsort( i ) = i;
 
     // naive insertion sort
     int i, j, tmp;
@@ -183,11 +178,12 @@ void Element::sortSymmetryFunctions( t_SF SF, h_t_int h_numSFperElem,
     {
         j = i;
         // explicit condition for sort
-        while ( j > 0 && compareSF( SF, attype, SFvector[j - 1], SFvector[j] ) )
+        while ( j > 0 &&
+                compareSF( SF, attype, h_SFsort( j - 1 ), h_SFsort( j ) ) )
         {
-            tmp = SFvector[j];
-            SFvector[j] = SFvector[j - 1];
-            SFvector[j - 1] = tmp;
+            tmp = h_SFsort( j );
+            h_SFsort( j ) = h_SFsort( j - 1 );
+            h_SFsort( j - 1 ) = tmp;
             --j;
         }
     }
@@ -195,12 +191,11 @@ void Element::sortSymmetryFunctions( t_SF SF, h_t_int h_numSFperElem,
     int tmpindex;
     for ( int i = 0; i < size; ++i )
     {
-        SF( attype, i, 13 ) = SFvector[i];
+        SF( attype, i, 13 ) = h_SFsort( i );
         tmpindex = SF( attype, i, 13 );
         SF( attype, tmpindex, 14 ) = i;
     }
 
-    delete[] SFvector;
     return;
 }
 

--- a/src/force_types/nnp_element.h
+++ b/src/force_types/nnp_element.h
@@ -96,7 +96,8 @@ class Element
      */
     void setupSymmetryFunctionGroups( t_SF SF, t_SFGmemberlist SFGmemberlist,
                                       int attype, int ( &countertotal )[2],
-                                      int ( &countergtotal )[2] );
+                                      int ( &countergtotal )[2],
+                                      int maxSFperElem );
     /** Print symmetry function group info.
      */
     vector<string>

--- a/src/force_types/nnp_element.h
+++ b/src/force_types/nnp_element.h
@@ -73,7 +73,7 @@ class Element
     void addSymmetryFunction( string const &parameters,
                               vector<string> elementStrings, int attype,
                               t_SF SF, double convLength,
-                              int ( &countertotal )[2] );
+                              h_t_int h_numSFperElem );
     /** Change length unit for all symmetry functions.
      *
      * @param[in] convLength Length unit conversion factor.
@@ -81,21 +81,21 @@ class Element
     void changeLengthUnitSymmetryFunctions( double convLength );
     /** Sort all symmetry function.
      */
-    void sortSymmetryFunctions( t_SF SF, h_t_mass h_numSFperElem, int attype );
+    void sortSymmetryFunctions( t_SF SF, h_t_int h_numSFperElem, int attype );
     /** Print symmetry function parameter value information.
      */
     bool compareSF( t_SF SF, int attype, int index1, int index2 );
     vector<string>
     infoSymmetryFunctionParameters( t_SF SF, int attype,
-                                    int ( &countertotal )[2] ) const;
-    vector<string>
-    infoSymmetryFunctionScaling( ScalingType scalingType, t_SF SF,
-                                 t_SFscaling SFscaling, int attype,
-                                 int ( &countertotal )[2] ) const;
+                                    h_t_int h_numSFperElem ) const;
+    vector<string> infoSymmetryFunctionScaling( ScalingType scalingType,
+                                                t_SF SF, t_SFscaling SFscaling,
+                                                int attype,
+                                                h_t_int h_numSFperElem ) const;
     /** Set up symmetry function groups.
      */
     void setupSymmetryFunctionGroups( t_SF SF, t_SFGmemberlist SFGmemberlist,
-                                      int attype, int ( &countertotal )[2],
+                                      int attype, h_t_int h_numSFperElem,
                                       int ( &countergtotal )[2],
                                       int maxSFperElem );
     /** Print symmetry function group info.
@@ -110,7 +110,7 @@ class Element
      */
     void setCutoffFunction( CutoffFunction::CutoffType const cutoffType,
                             double const cutoffAlpha, t_SF SF, int attype,
-                            int ( &countertotal )[2] );
+                            h_t_int h_numSFperElem );
     /** Set scaling of all symmetry functions.
      *
      * @param[in] scalingType Type of scaling, see
@@ -123,12 +123,12 @@ class Element
     void setScaling( ScalingType scalingType,
                      vector<string> const &statisticsLine, double minS,
                      double maxS, t_SF SF, t_SFscaling SFscaling, int attype,
-                     int ( &countertotal )[2] ) const;
+                     h_t_int h_numSFperElem ) const;
     /** Get number of symmetry functions.
      *
      * @return Number of symmetry functions.
      */
-    size_t numSymmetryFunctions( int attype, int ( &countertotal )[2] ) const;
+    size_t numSymmetryFunctions( int attype, h_t_int h_numSFperElem ) const;
     /** Get maximum of required minimum number of neighbors for all symmetry
      * functions for this element.
      *
@@ -140,13 +140,13 @@ class Element
      * @return Minimum cutoff radius.
      */
     double getMinCutoffRadius( t_SF SF, int attype,
-                               int ( &countertotal )[2] ) const;
+                               h_t_int h_numSFperElem ) const;
     /** Get maximum cutoff radius of all symmetry functions.
      *
      * @return Maximum cutoff radius.
      */
     double getMaxCutoffRadius( t_SF SF, int attype,
-                               int ( &countertotal )[2] ) const;
+                               h_t_int h_numSFperElem ) const;
     /** Update symmetry function statistics.
      *
      * @param[in] atom Atom with symmetry function values.
@@ -212,9 +212,9 @@ inline double Element::getAtomicEnergyOffset() const
 inline string Element::getSymbol() const { return symbol; }
 
 inline size_t Element::numSymmetryFunctions( int attype,
-                                             int ( &countertotal )[2] ) const
+                                             h_t_int h_numSFperElem ) const
 {
-    return countertotal[attype];
+    return h_numSFperElem( attype );
 }
 
 inline void Element::setScalingType( ScalingType scalingType,

--- a/src/force_types/nnp_element.h
+++ b/src/force_types/nnp_element.h
@@ -96,13 +96,14 @@ class Element
      */
     void setupSymmetryFunctionGroups( t_SF SF, t_SFGmemberlist SFGmemberlist,
                                       int attype, h_t_int h_numSFperElem,
-                                      int ( &countergtotal )[2],
+                                      h_t_int h_numSFGperElem,
                                       int maxSFperElem );
     /** Print symmetry function group info.
      */
-    vector<string>
-    infoSymmetryFunctionGroups( t_SF SF, t_SFGmemberlist SFGmemberlist,
-                                int attype, int ( &countergtotal )[2] ) const;
+    vector<string> infoSymmetryFunctionGroups( t_SF SF,
+                                               t_SFGmemberlist SFGmemberlist,
+                                               int attype,
+                                               h_t_int h_numSFGperElem ) const;
     /** Set cutoff function for all symmetry functions.
      *
      * @param[in] cutoffType Type of cutoff function.

--- a/src/force_types/nnp_mode.cpp
+++ b/src/force_types/nnp_mode.cpp
@@ -151,17 +151,11 @@ void Mode::setupElementMap()
     // resize to match number of element types
     numElements = elementStrings.size();
 
-    // setup device and host views
-    // deep copy back when needed for calculations
-    // setup SF info storage
+    // setup SF host views
+    // create device mirrors if needed below
     SF = t_SF( "ForceNNP::SF", numElements, MAX_SF );
     SFscaling = t_SFscaling( "ForceNNP::SFscaling", numElements, MAX_SF );
     SFGmemberlist = t_SFGmemberlist( "ForceNNP::SFGmemberlist", numElements );
-
-    d_SF = d_t_SF( "ForceNNP::SF", numElements, MAX_SF );
-    d_SFscaling = d_t_SFscaling( "ForceNNP::SFscaling", numElements, MAX_SF );
-    d_SFGmemberlist =
-        d_t_SFGmemberlist( "ForceNNP::SFGmemberlist", numElements );
 
     log << "*****************************************"
            "**************************************\n";
@@ -408,8 +402,7 @@ void Mode::setupSymmetryFunctions()
            "**************************************\n";
 
     numSFperElem =
-        t_mass( "ForceNNP::numSymmetryFunctionsPerElement", numElements );
-    Kokkos::deep_copy( numSFperElem, h_numSFperElem );
+        Kokkos::create_mirror_view_and_copy( MemorySpace(), h_numSFperElem );
 
     return;
 }
@@ -548,9 +541,9 @@ void Mode::setupSymmetryFunctionScaling( string const &fileName )
     log << "*****************************************"
            "**************************************\n";
 
-    Kokkos::deep_copy( d_SF, SF );
-    Kokkos::deep_copy( d_SFscaling, SFscaling );
-    Kokkos::deep_copy( d_SFGmemberlist, SFGmemberlist );
+    d_SF = Kokkos::create_mirror_view_and_copy( MemorySpace(), SF );
+    d_SFscaling = Kokkos::create_mirror_view_and_copy( MemorySpace(), SFscaling );
+    d_SFGmemberlist = Kokkos::create_mirror_view_and_copy( MemorySpace(), SFGmemberlist );
 
     return;
 }
@@ -806,16 +799,10 @@ void Mode::setupNeuralNetworkWeights( string const &fileNameFormat )
     log << "*****************************************"
            "**************************************\n";
 
-    bias = d_t_bias( "ForceNNP::biases", numElements, numLayers, maxNeurons );
-    weights = d_t_weights( "ForceNNP::weights", numElements, numLayers,
-                           maxNeurons, maxNeurons );
-    AF = d_t_int( "ActivationFunctions", numLayers );
-    numNeuronsPerLayer = d_t_int( "numNeuronsPerLayer", numLayers );
-
-    Kokkos::deep_copy( bias, h_bias );
-    Kokkos::deep_copy( weights, h_weights );
-    Kokkos::deep_copy( AF, h_AF );
-    Kokkos::deep_copy( numNeuronsPerLayer, h_numNeuronsPerLayer );
+    bias = Kokkos::create_mirror_view_and_copy( MemorySpace(), h_bias );
+    weights = Kokkos::create_mirror_view_and_copy( MemorySpace(), h_weights );
+    AF = Kokkos::create_mirror_view_and_copy( MemorySpace(), h_AF );
+    numNeuronsPerLayer = Kokkos::create_mirror_view_and_copy( MemorySpace(), h_numNeuronsPerLayer );
 
     return;
 }

--- a/src/force_types/nnp_mode.cpp
+++ b/src/force_types/nnp_mode.cpp
@@ -598,12 +598,16 @@ void Mode::setupSymmetryFunctionGroups()
     log << "sfi .... Symmetry function index.\n";
     log << "e ...... Recalculate exponential term.\n";
     log << "\n";
+
+    h_numSFGperElem =
+        h_t_int( "numSymmetryFunctionGroupsPerElement", numElements );
+
     for ( vector<Element>::iterator it = elements.begin(); it != elements.end();
           ++it )
     {
         int attype = it->getIndex();
         it->setupSymmetryFunctionGroups( SF, SFGmemberlist, attype,
-                                         h_numSFperElem, countergtotal,
+                                         h_numSFperElem, h_numSFGperElem,
                                          maxSFperElem );
         log << nnp::strpr( "Short range atomic symmetry function groups "
                            "element %2s :\n",
@@ -615,13 +619,16 @@ void Mode::setupSymmetryFunctionGroups()
         log << "-----------------------------------------"
                "--------------------------------------\n";
         log << it->infoSymmetryFunctionGroups( SF, SFGmemberlist, attype,
-                                               countergtotal );
+                                               h_numSFGperElem );
         log << "-----------------------------------------"
                "--------------------------------------\n";
     }
 
     log << "*****************************************"
            "**************************************\n";
+
+    numSFGperElem =
+        Kokkos::create_mirror_view_and_copy( MemorySpace(), h_numSFGperElem );
 
     return;
 }

--- a/src/force_types/nnp_mode.cpp
+++ b/src/force_types/nnp_mode.cpp
@@ -169,7 +169,7 @@ void Mode::setupElementMap()
     return;
 }
 
-h_t_mass Mode::setupElements( h_t_mass atomicEnergyOffset )
+void Mode::setupElements()
 {
     log << "\n";
     log << "*** SETUP: ELEMENTS *********************"
@@ -218,7 +218,8 @@ h_t_mass Mode::setupElements( h_t_mass atomicEnergyOffset )
            "energies.\n";
     log << "*****************************************"
            "**************************************\n";
-    return atomicEnergyOffset;
+
+    return;
 }
 
 void Mode::setupCutoff()
@@ -316,7 +317,7 @@ void Mode::setupCutoff()
     return;
 }
 
-h_t_mass Mode::setupSymmetryFunctions( h_t_mass h_numSFperElem )
+void Mode::setupSymmetryFunctions()
 {
     h_numSFperElem =
         h_t_mass( "ForceNNP::numSymmetryFunctionsPerElement", numElements );
@@ -406,7 +407,11 @@ h_t_mass Mode::setupSymmetryFunctions( h_t_mass h_numSFperElem )
     log << "*****************************************"
            "**************************************\n";
 
-    return h_numSFperElem;
+    numSFperElem =
+        t_mass( "ForceNNP::numSymmetryFunctionsPerElement", numElements );
+    Kokkos::deep_copy( numSFperElem, h_numSFperElem );
+
+    return;
 }
 
 void Mode::setupSymmetryFunctionScaling( string const &fileName )

--- a/src/force_types/nnp_mode.cpp
+++ b/src/force_types/nnp_mode.cpp
@@ -186,7 +186,6 @@ void Mode::setupElements()
         {
             vector<string> args = nnp::split( nnp::reduce( it->second.first ) );
             const char *estring = args.at( 0 ).c_str();
-            // np.where element symbol == symbol encountered during parsing
             for ( size_t i = 0; i < elementStrings.size(); ++i )
             {
                 if ( strcmp( elementStrings[i].c_str(), estring ) == 0 )
@@ -322,7 +321,6 @@ void Mode::setupSymmetryFunctions()
         vector<string> args = nnp::split( nnp::reduce( it->second.first ) );
         int type = 0;
         const char *estring = args.at( 0 ).c_str();
-        // np.where element symbol == symbol encountered during parsing
         for ( size_t i = 0; i < elementStrings.size(); ++i )
         {
             if ( strcmp( elementStrings[i].c_str(), estring ) == 0 )
@@ -351,7 +349,6 @@ void Mode::setupSymmetryFunctions()
         vector<string> args = nnp::split( nnp::reduce( it->second.first ) );
         int type = 0;
         const char *estring = args.at( 0 ).c_str();
-        // np.where element symbol == symbol encountered during parsing
         for ( size_t i = 0; i < elementStrings.size(); ++i )
         {
             if ( strcmp( elementStrings[i].c_str(), estring ) == 0 )
@@ -780,7 +777,6 @@ void Mode::setupNeuralNetworkWeights( string const &fileNameFormat )
           ++it )
     {
         const char *estring = elementStrings[count].c_str();
-        // np.where element symbol == symbol encountered in knownElements
         for ( size_t i = 0; i < knownElements.size(); ++i )
         {
             if ( strcmp( knownElements[i].c_str(), estring ) == 0 )

--- a/src/force_types/nnp_mode.h
+++ b/src/force_types/nnp_mode.h
@@ -394,6 +394,7 @@ class Mode
 
     h_t_mass h_numSFperElem;
     t_mass numSFperElem;
+    int maxSFperElem;
 
     int countertotal[2] = {0, 0};
     int countergtotal[2] = {0, 0};

--- a/src/force_types/nnp_mode.h
+++ b/src/force_types/nnp_mode.h
@@ -394,9 +394,9 @@ class Mode
 
     h_t_int h_numSFperElem;
     d_t_int numSFperElem;
+    h_t_int h_numSFGperElem;
+    d_t_int numSFGperElem;
     int maxSFperElem;
-
-    int countergtotal[2] = {0, 0};
 
     bool normalize;
     bool checkExtrapolationWarnings;

--- a/src/force_types/nnp_mode.h
+++ b/src/force_types/nnp_mode.h
@@ -335,20 +335,25 @@ class Mode
     KOKKOS_INLINE_FUNCTION
     double scale( int attype, double value, int k, d_t_SFscaling SFscaling );
 
-    template <class t_System, class t_System_NNP, class t_neigh_list,
-              class t_neigh_parallel, class t_angle_parallel>
-    void calculateForces( t_System *s, t_System_NNP *system_nnp,
-                          t_neigh_list neigh_list );
+    template <class t_slice_x, class t_slice_f, class t_slice_type,
+              class t_slice_dEdG, class t_neigh_list, class t_neigh_parallel,
+              class t_angle_parallel>
+    void calculateForces( t_slice_x x, t_slice_f f, t_slice_type type,
+                          t_slice_dEdG dEdG, t_neigh_list neigh_list,
+                          int N_local );
 
-    template <class t_System, class t_System_NNP, class t_neigh_list,
-              class t_neigh_parallel, class t_angle_parallel>
-    void calculateAtomicNeuralNetworks( t_System *s, t_System_NNP *system_nnp,
-                                        t_mass numSFperElem );
+    template <class t_slice_type, class t_slice_G, class t_slice_dEdG,
+              class t_slice_E>
+    void calculateAtomicNeuralNetworks( t_slice_type type, t_slice_G G,
+                                        t_slice_dEdG dEdG, t_slice_E E,
+                                        t_mass numSFperElem, int N_local );
 
-    template <class t_System, class t_System_NNP, class t_neigh_list,
-              class t_neigh_parallel, class t_angle_parallel>
-    void calculateSymmetryFunctionGroups( t_System *s, t_System_NNP *system_nnp,
-                                          t_neigh_list neigh_list );
+    template <class t_slice_x, class t_slice_type, class t_slice_G,
+              class t_neigh_list, class t_neigh_parallel,
+              class t_angle_parallel>
+    void calculateSymmetryFunctionGroups( t_slice_x x, t_slice_type type,
+                                          t_slice_G G, t_neigh_list neigh_list,
+                                          int N_local );
 
     /// Global log file.
     nnp::Log log;

--- a/src/force_types/nnp_mode.h
+++ b/src/force_types/nnp_mode.h
@@ -119,7 +119,7 @@ class Mode
      * Uses keywords `number_of_elements` and `atom_energy`. This function
      * should follow immediately after setupElementMap().
      */
-    h_t_mass setupElements( h_t_mass atomicEnergyOffset );
+    void setupElements();
     /** Set up cutoff function for all symmetry functions.
      *
      * Uses keyword `cutoff_type`. Cutoff parameters are read from settings
@@ -133,7 +133,7 @@ class Mode
      * Uses keyword `symfunction_short`. Reads all symmetry functions from
      * settings and automatically assigns them to the correct element.
      */
-    h_t_mass setupSymmetryFunctions( h_t_mass h_numSFperElem );
+    void setupSymmetryFunctions();
     /** Set up symmetry function scaling from file.
      *
      * @param[in] fileName Scaling file name.
@@ -346,7 +346,7 @@ class Mode
               class t_slice_E>
     void calculateAtomicNeuralNetworks( t_slice_type type, t_slice_G G,
                                         t_slice_dEdG dEdG, t_slice_E E,
-                                        t_mass numSFperElem, int N_local );
+                                        int N_local );
 
     template <class t_slice_x, class t_slice_type, class t_slice_G,
               class t_neigh_list, class t_neigh_parallel,
@@ -389,6 +389,12 @@ class Mode
     int AF[4];
     // int* numNeuronsPerLayer = new int[numLayers];
     // int* AF = new int[numLayers];
+
+    // Not ever used in a device kernel
+    h_t_mass atomicEnergyOffset;
+
+    h_t_mass h_numSFperElem;
+    t_mass numSFperElem;
 
     int countertotal[2] = {0, 0};
     int countergtotal[2] = {0, 0};

--- a/src/force_types/nnp_mode.h
+++ b/src/force_types/nnp_mode.h
@@ -392,11 +392,10 @@ class Mode
 
     h_t_mass atomicEnergyOffset;
 
-    h_t_mass h_numSFperElem;
-    t_mass numSFperElem;
+    h_t_int h_numSFperElem;
+    d_t_int numSFperElem;
     int maxSFperElem;
 
-    int countertotal[2] = {0, 0};
     int countergtotal[2] = {0, 0};
 
     bool normalize;

--- a/src/force_types/nnp_mode.h
+++ b/src/force_types/nnp_mode.h
@@ -385,12 +385,11 @@ class Mode
     t_bias h_bias;
     t_weights h_weights;
     int numLayers, numHiddenLayers, maxNeurons;
-    int numNeuronsPerLayer[4];
-    int AF[4];
-    // int* numNeuronsPerLayer = new int[numLayers];
-    // int* AF = new int[numLayers];
+    d_t_int numNeuronsPerLayer;
+    h_t_int h_numNeuronsPerLayer;
+    d_t_int AF;
+    h_t_int h_AF;
 
-    // Not ever used in a device kernel
     h_t_mass atomicEnergyOffset;
 
     h_t_mass h_numSFperElem;

--- a/src/force_types/nnp_mode_impl.h
+++ b/src/force_types/nnp_mode_impl.h
@@ -55,7 +55,7 @@ void Mode::calculateSymmetryFunctionGroups( t_slice_x x, t_slice_type type,
         T_F_FLOAT dxij, dyij, dzij;
 
         int attype = type( i );
-        for ( int groupIndex = 0; groupIndex < countergtotal[attype];
+        for ( int groupIndex = 0; groupIndex < numSFGperElem( attype );
               ++groupIndex )
         {
             if ( d_SF( attype, d_SFGmemberlist( attype, groupIndex, 0 ), 1 ) ==
@@ -107,7 +107,7 @@ void Mode::calculateSymmetryFunctionGroups( t_slice_x x, t_slice_type type,
         double eta, rs, lambda, zeta;
 
         int attype = type( i );
-        for ( int groupIndex = 0; groupIndex < countergtotal[attype];
+        for ( int groupIndex = 0; groupIndex < numSFGperElem( attype );
               ++groupIndex )
         {
             if ( d_SF( attype, d_SFGmemberlist( attype, groupIndex, 0 ), 1 ) ==
@@ -225,7 +225,7 @@ void Mode::calculateSymmetryFunctionGroups( t_slice_x x, t_slice_type type,
         int memberindex0;
         int memberindex, globalIndex;
         double raw_value = 0.0;
-        for ( int groupIndex = 0; groupIndex < countergtotal[attype];
+        for ( int groupIndex = 0; groupIndex < numSFGperElem( attype );
               ++groupIndex )
         {
             memberindex0 = d_SFGmemberlist( attype, groupIndex, 0 );
@@ -362,7 +362,7 @@ void Mode::calculateForces( t_slice_x x, t_slice_f f_a, t_slice_type type,
 
         int attype = type( i );
 
-        for ( int groupIndex = 0; groupIndex < countergtotal[attype];
+        for ( int groupIndex = 0; groupIndex < numSFGperElem( attype );
               ++groupIndex )
         {
             if ( d_SF( attype, d_SFGmemberlist( attype, groupIndex, 0 ), 1 ) ==
@@ -435,7 +435,7 @@ void Mode::calculateForces( t_slice_x x, t_slice_f f_a, t_slice_type type,
         int memberindex, globalIndex;
 
         int attype = type( i );
-        for ( int groupIndex = 0; groupIndex < countergtotal[attype];
+        for ( int groupIndex = 0; groupIndex < numSFGperElem( attype );
               ++groupIndex )
         {
             if ( d_SF( attype, d_SFGmemberlist( attype, groupIndex, 0 ), 1 ) ==

--- a/src/force_types/nnp_mode_impl.h
+++ b/src/force_types/nnp_mode_impl.h
@@ -120,10 +120,6 @@ void Mode::calculateSymmetryFunctionGroups( t_slice_x x, t_slice_type type,
                 size_t size =
                     d_SFGmemberlist( attype, groupIndex, maxSFperElem );
 
-                // Prevent problematic condition in loop test below (j <
-                // numNeighbors - 1).
-                // if (num_neighs == 0) num_neighs = 1;
-
                 nej = type( j );
                 dxij = ( x( i, 0 ) - x( j, 0 ) ) * CFLENGTH * convLength;
                 dyij = ( x( i, 1 ) - x( j, 1 ) ) * CFLENGTH * convLength;
@@ -447,9 +443,6 @@ void Mode::calculateForces( t_slice_x x, t_slice_f f_a, t_slice_type type,
                 double rc = d_SF( attype, memberindex0, 7 );
                 size_t size =
                     d_SFGmemberlist( attype, groupIndex, maxSFperElem );
-                // Prevent problematic condition in loop test below (j <
-                // numNeighbors - 1).
-                // if (num_neighs == 0) num_neighs = 1;
 
                 nej = type( j );
                 dxij = ( x( i, 0 ) - x( j, 0 ) ) * CFLENGTH * convLength;

--- a/src/force_types/nnp_mode_impl.h
+++ b/src/force_types/nnp_mode_impl.h
@@ -281,12 +281,12 @@ void Mode::calculateAtomicNeuralNetworks( t_slice_type type, t_slice_G G,
                     dtmp += weights( attype, l - 1, i, j ) *
                             NN( atomindex, l - 1, j );
                 dtmp += bias( attype, l - 1, i );
-                if ( AF[l] == 0 )
+                if ( AF( l ) == 0 )
                 {
                     NN( atomindex, l, i ) = dtmp;
                     dfdx( atomindex, l, i ) = 1.0;
                 }
-                else if ( AF[l] == 1 )
+                else if ( AF( l ) == 1 )
                 {
                     dtmp = tanh( dtmp );
                     NN( atomindex, l, i ) = dtmp;
@@ -306,11 +306,11 @@ void Mode::calculateAtomicNeuralNetworks( t_slice_type type, t_slice_G G,
 
             for ( int l = 1; l < numHiddenLayers + 1; l++ )
             {
-                for ( int i2 = 0; i2 < numNeuronsPerLayer[l + 1]; i2++ )
+                for ( int i2 = 0; i2 < numNeuronsPerLayer( l + 1 ); i2++ )
                 {
                     outer( atomindex, l - 1, i2 ) = 0.0;
 
-                    for ( int i1 = 0; i1 < numNeuronsPerLayer[l]; i1++ )
+                    for ( int i1 = 0; i1 < numNeuronsPerLayer( l ); i1++ )
                         outer( atomindex, l - 1, i2 ) +=
                             weights( attype, l, i2, i1 ) *
                             inner( atomindex, l - 1, i1 );

--- a/src/force_types/nnp_mode_impl.h
+++ b/src/force_types/nnp_mode_impl.h
@@ -46,6 +46,14 @@ void Mode::calculateSymmetryFunctionGroups( t_slice_x x, t_slice_type type,
 
     auto calc_radial_symm_op = KOKKOS_LAMBDA( const int i, const int j )
     {
+        double pfcij = 0.0;
+        double pdfcij = 0.0;
+        double eta, rs;
+        size_t nej;
+        int memberindex, globalIndex;
+        double rij, r2ij;
+        T_F_FLOAT dxij, dyij, dzij;
+
         int attype = type( i );
         for ( int groupIndex = 0; groupIndex < countergtotal[attype];
               ++groupIndex )
@@ -59,11 +67,6 @@ void Mode::calculateSymmetryFunctionGroups( t_slice_x x, t_slice_type type,
                 size_t size =
                     d_SFGmemberlist( attype, groupIndex, maxSFperElem );
 
-                double pfcij, pdfcij, eta, rs;
-                size_t nej;
-                int memberindex, globalIndex;
-                double rij, r2ij;
-                T_F_FLOAT dxij, dyij, dzij;
                 nej = type( j );
                 dxij = ( x( i, 0 ) - x( j, 0 ) ) * CFLENGTH * convLength;
                 dyij = ( x( i, 1 ) - x( j, 1 ) ) * CFLENGTH * convLength;
@@ -94,6 +97,15 @@ void Mode::calculateSymmetryFunctionGroups( t_slice_x x, t_slice_type type,
     auto calc_angular_symm_op =
         KOKKOS_LAMBDA( const int i, const int j, const int k )
     {
+        double pfcij = 0.0;
+        double pdfcij = 0.0;
+        double pfcik, pdfcik, pfcjk, pdfcjk;
+        size_t nej, nek;
+        int memberindex, globalIndex;
+        double rij, r2ij, rik, r2ik, rjk, r2jk;
+        T_F_FLOAT dxij, dyij, dzij, dxik, dyik, dzik, dxjk, dyjk, dzjk;
+        double eta, rs, lambda, zeta;
+
         int attype = type( i );
         for ( int groupIndex = 0; groupIndex < countergtotal[attype];
               ++groupIndex )
@@ -112,12 +124,6 @@ void Mode::calculateSymmetryFunctionGroups( t_slice_x x, t_slice_type type,
                 // numNeighbors - 1).
                 // if (num_neighs == 0) num_neighs = 1;
 
-                double pfcij, pdfcij, pfcik, pdfcik, pfcjk, pdfcjk;
-                size_t nej, nek;
-                int memberindex, globalIndex;
-                double rij, r2ij, rik, r2ik, rjk, r2jk;
-                T_F_FLOAT dxij, dyij, dzij, dxik, dyik, dzik, dxjk, dyjk, dzjk;
-                double eta, rs, lambda, zeta;
                 nej = type( j );
                 dxij = ( x( i, 0 ) - x( j, 0 ) ) * CFLENGTH * convLength;
                 dyij = ( x( i, 1 ) - x( j, 1 ) ) * CFLENGTH * convLength;
@@ -347,6 +353,13 @@ void Mode::calculateForces( t_slice_x x, t_slice_f f_a, t_slice_type type,
 
     auto calc_radial_force_op = KOKKOS_LAMBDA( const int i, const int j )
     {
+        double pfcij = 0.0;
+        double pdfcij = 0.0;
+        double rij, r2ij;
+        T_F_FLOAT dxij, dyij, dzij;
+        double eta, rs;
+        int memberindex, globalIndex;
+
         int attype = type( i );
 
         for ( int groupIndex = 0; groupIndex < countergtotal[attype];
@@ -361,11 +374,6 @@ void Mode::calculateForces( t_slice_x x, t_slice_f f_a, t_slice_type type,
                 size_t size =
                     d_SFGmemberlist( attype, groupIndex, maxSFperElem );
 
-                double pfcij, pdfcij;
-                double rij, r2ij;
-                T_F_FLOAT dxij, dyij, dzij;
-                double eta, rs;
-                int memberindex, globalIndex;
                 size_t nej = type( j );
                 dxij = ( x( i, 0 ) - x( j, 0 ) ) * CFLENGTH * convLength;
                 dyij = ( x( i, 1 ) - x( j, 1 ) ) * CFLENGTH * convLength;
@@ -417,6 +425,15 @@ void Mode::calculateForces( t_slice_x x, t_slice_f f_a, t_slice_type type,
     auto calc_angular_force_op =
         KOKKOS_LAMBDA( const int i, const int j, const int k )
     {
+        double pfcij = 0.0;
+        double pdfcij = 0.0;
+        double pfcik, pdfcik, pfcjk, pdfcjk;
+        size_t nej, nek;
+        double rij, r2ij, rik, r2ik, rjk, r2jk;
+        T_F_FLOAT dxij, dyij, dzij, dxik, dyik, dzik, dxjk, dyjk, dzjk;
+        double eta, rs, lambda, zeta;
+        int memberindex, globalIndex;
+
         int attype = type( i );
         for ( int groupIndex = 0; groupIndex < countergtotal[attype];
               ++groupIndex )
@@ -434,12 +451,6 @@ void Mode::calculateForces( t_slice_x x, t_slice_f f_a, t_slice_type type,
                 // numNeighbors - 1).
                 // if (num_neighs == 0) num_neighs = 1;
 
-                double pfcij, pdfcij, pfcik, pdfcik, pfcjk, pdfcjk;
-                size_t nej, nek;
-                double rij, r2ij, rik, r2ik, rjk, r2jk;
-                T_F_FLOAT dxij, dyij, dzij, dxik, dyik, dzik, dxjk, dyjk, dzjk;
-                double eta, rs, lambda, zeta;
-                int memberindex, globalIndex;
                 nej = type( j );
                 dxij = ( x( i, 0 ) - x( j, 0 ) ) * CFLENGTH * convLength;
                 dyij = ( x( i, 1 ) - x( j, 1 ) ) * CFLENGTH * convLength;

--- a/src/force_types/nnp_mode_impl.h
+++ b/src/force_types/nnp_mode_impl.h
@@ -56,7 +56,8 @@ void Mode::calculateSymmetryFunctionGroups( t_slice_x x, t_slice_type type,
                 size_t memberindex0 = d_SFGmemberlist( attype, groupIndex, 0 );
                 size_t e1 = d_SF( attype, memberindex0, 2 );
                 double rc = d_SF( attype, memberindex0, 7 );
-                size_t size = d_SFGmemberlist( attype, groupIndex, MAX_SF );
+                size_t size =
+                    d_SFGmemberlist( attype, groupIndex, maxSFperElem );
 
                 double pfcij, pdfcij, eta, rs;
                 size_t nej;
@@ -104,7 +105,8 @@ void Mode::calculateSymmetryFunctionGroups( t_slice_x x, t_slice_type type,
                 size_t e1 = d_SF( attype, memberindex0, 2 );
                 size_t e2 = d_SF( attype, memberindex0, 3 );
                 double rc = d_SF( attype, memberindex0, 7 );
-                size_t size = d_SFGmemberlist( attype, groupIndex, MAX_SF );
+                size_t size =
+                    d_SFGmemberlist( attype, groupIndex, maxSFperElem );
 
                 // Prevent problematic condition in loop test below (j <
                 // numNeighbors - 1).
@@ -222,7 +224,7 @@ void Mode::calculateSymmetryFunctionGroups( t_slice_x x, t_slice_type type,
         {
             memberindex0 = d_SFGmemberlist( attype, groupIndex, 0 );
 
-            size_t size = d_SFGmemberlist( attype, groupIndex, MAX_SF );
+            size_t size = d_SFGmemberlist( attype, groupIndex, maxSFperElem );
             for ( size_t k = 0; k < size; ++k )
             {
                 globalIndex = d_SF(
@@ -356,7 +358,8 @@ void Mode::calculateForces( t_slice_x x, t_slice_f f_a, t_slice_type type,
                 size_t memberindex0 = d_SFGmemberlist( attype, groupIndex, 0 );
                 size_t e1 = d_SF( attype, memberindex0, 2 );
                 double rc = d_SF( attype, memberindex0, 7 );
-                size_t size = d_SFGmemberlist( attype, groupIndex, MAX_SF );
+                size_t size =
+                    d_SFGmemberlist( attype, groupIndex, maxSFperElem );
 
                 double pfcij, pdfcij;
                 double rij, r2ij;
@@ -425,7 +428,8 @@ void Mode::calculateForces( t_slice_x x, t_slice_f f_a, t_slice_type type,
                 size_t e1 = d_SF( attype, memberindex0, 2 );
                 size_t e2 = d_SF( attype, memberindex0, 3 );
                 double rc = d_SF( attype, memberindex0, 7 );
-                size_t size = d_SFGmemberlist( attype, groupIndex, MAX_SF );
+                size_t size =
+                    d_SFGmemberlist( attype, groupIndex, maxSFperElem );
                 // Prevent problematic condition in loop test below (j <
                 // numNeighbors - 1).
                 // if (num_neighs == 0) num_neighs = 1;

--- a/src/force_types/nnp_mode_impl.h
+++ b/src/force_types/nnp_mode_impl.h
@@ -28,11 +28,6 @@
 #include <stdexcept> // std::runtime_error
 #include <string>
 
-#define NNP_VERSION "2.0.0"
-#define NNP_GIT_REV "7b73a36a9acfdcc80e44265bac92b055f41a1d07"
-#define NNP_GIT_REV_SHORT "7b73a36"
-#define NNP_GIT_BRANCH "master"
-
 using namespace std;
 using namespace nnpCbn;
 
@@ -255,7 +250,7 @@ template <class t_slice_type, class t_slice_G, class t_slice_dEdG,
           class t_slice_E>
 void Mode::calculateAtomicNeuralNetworks( t_slice_type type, t_slice_G G,
                                           t_slice_dEdG dEdG, t_slice_E E,
-                                          t_mass numSFperElem, int N_local )
+                                          int N_local )
 {
     NN = d_t_NN( "Mode::NN", N_local, numLayers, maxNeurons );
     dfdx = d_t_NN( "Mode::dfdx", N_local, numLayers, maxNeurons );

--- a/src/force_types/types_nnp.h
+++ b/src/force_types/types_nnp.h
@@ -54,8 +54,6 @@
 #include <Cabana_Core.hpp>
 #include <Kokkos_Core.hpp>
 
-// TODO: hardcoded
-#define MAX_SF 30
 constexpr double CFLENGTH = 1.889726;
 constexpr double CFENERGY = 0.036749;
 constexpr double CFFORCE = CFLENGTH / CFENERGY;
@@ -84,11 +82,9 @@ using t_SF = Kokkos::View<T_FLOAT * * [15], array_layout, Kokkos::HostSpace>;
 using d_t_SFscaling = Kokkos::View<T_FLOAT * * [8]>;
 using t_SFscaling =
     Kokkos::View<T_FLOAT * * [8], array_layout, Kokkos::HostSpace>;
-using d_t_SFGmemberlist =
-    Kokkos::View<T_INT *
-                 [MAX_SF + 1][MAX_SF + 1]>; //+1 to store size of memberlist
-using t_SFGmemberlist = Kokkos::View<T_INT * [MAX_SF + 1][MAX_SF + 1],
-                                     array_layout, Kokkos::HostSpace>;
+using d_t_SFGmemberlist = Kokkos::View<T_INT ***>;
+using t_SFGmemberlist =
+    Kokkos::View<T_INT ***, array_layout, Kokkos::HostSpace>;
 
 using d_t_bias = Kokkos::View<T_FLOAT ***>;
 using t_bias = Kokkos::View<T_FLOAT ***, array_layout, Kokkos::HostSpace>;

--- a/src/force_types/types_nnp.h
+++ b/src/force_types/types_nnp.h
@@ -76,6 +76,9 @@ enum {
 
 typedef ExecutionSpace::array_layout array_layout; // TODO: check this
 using h_t_mass = Kokkos::View<T_V_FLOAT *, array_layout, Kokkos::HostSpace>;
+using d_t_int = Kokkos::View<T_INT *>;
+using h_t_int = Kokkos::View<T_INT *, array_layout, Kokkos::HostSpace>;
+
 using d_t_SF = Kokkos::View<T_FLOAT * * [15]>;
 using t_SF = Kokkos::View<T_FLOAT * * [15], array_layout, Kokkos::HostSpace>;
 using d_t_SFscaling = Kokkos::View<T_FLOAT * * [8]>;

--- a/src/system_types/system_nnp_1aosoa.h
+++ b/src/system_types/system_nnp_1aosoa.h
@@ -25,7 +25,8 @@ template <>
 class System_NNP<AoSoA1>
 {
     using t_tuple_NNP =
-        Cabana::MemberTypes<T_FLOAT[MAX_SF], T_FLOAT[MAX_SF], T_FLOAT>;
+        Cabana::MemberTypes<T_FLOAT[CabanaMD_MAXSYMMFUNC_NNP],
+                            T_FLOAT[CabanaMD_MAXSYMMFUNC_NNP], T_FLOAT>;
     using AoSoA_NNP_1 =
         Cabana::AoSoA<t_tuple_NNP, MemorySpace, CabanaMD_VECTORLENGTH_NNP>;
     AoSoA_NNP_1 aosoa_0;

--- a/src/system_types/system_nnp_3aosoa.h
+++ b/src/system_types/system_nnp_3aosoa.h
@@ -24,7 +24,8 @@
 template <>
 class System_NNP<AoSoA3>
 {
-    using t_tuple_NNP_SF = Cabana::MemberTypes<T_FLOAT[MAX_SF]>;
+    using t_tuple_NNP_SF =
+        Cabana::MemberTypes<T_FLOAT[CabanaMD_MAXSYMMFUNC_NNP]>;
     using t_tuple_NNP_fl = Cabana::MemberTypes<T_FLOAT>;
     using AoSoA_NNP_SF =
         Cabana::AoSoA<t_tuple_NNP_SF, MemorySpace, CabanaMD_VECTORLENGTH_NNP>;


### PR DESCRIPTION
First, this removes any dependency of NNP kernels on CabanaMD specific types (`System`), instead passing Cabana types (slices and neighbor lists)

It also aligns a few setup functions with the main n2p2 code (where possible). 

Finally, arrays are converted to `Kokkos::Views` for more flexibility, with `create_mirror_view_and_copy` to reduce copying.

One downside is that while the number of symmetry functions is now dynamic within the NNP code, a compile time max number is needed for the AoSoAs.

 This is one more piece towards #37 