### PR TITLE
Fix test backend capitalization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
 before_script:
   - ccache -z
   - KOKKOS_OPTS=( -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DKokkos_ENABLE_HWLOC=ON -DKokkos_CXX_STANDARD=14 )
-  - for i in ${BACKENDS}; do KOKKOS_OPTS+=( -DKokkos_ENABLE_${i^^}=ON ); done
+  - for i in ${BACKENDS}; do KOKKOS_OPTS+=( -DKokkos_ENABLE_${i}=ON ); done
   - for i in ${BACKENDS}; do CABANA_OPTS+=( -DCabana_REQUIRE_${i}=ON ); done
   - for i in ${BACKENDS}; do CABANAMD_OPTS+=( -DCabanaMD_REQUIRE_${i}=ON ); done
     # LD_LIBRARY_PATH workaround for libomp: https://github.com/travis-ci/travis-ci/issues/8613

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -12,7 +12,7 @@ macro(CabanaMD_add_tests)
   set(CABANAMD_UNIT_TEST_NUMTHREADS 1 2)
   set(CABANAMD_UNIT_TEST_MAIN unit_test_main.cpp)
 
-  foreach(_device Serial OpenMP Cuda)
+  foreach(_device SERIAL OPENMP CUDA)
     if(Kokkos_ENABLE_${_device})
       string(TOUPPER ${_device} _uppercase_device)
       set(_dir ${CMAKE_CURRENT_BINARY_DIR}/${_uppercase_device})
@@ -29,7 +29,7 @@ macro(CabanaMD_add_tests)
         target_link_libraries(${_target} PRIVATE CabanaMD gtest CabanaMD)
 
         foreach(_np ${CABANAMD_UNIT_TEST_MPIEXEC_NUMPROCS})
-          if(_device STREQUAL THREADS OR _device STREQUAL OpenMP)
+          if(_device STREQUAL OPENMP)
             foreach(_thread ${CABANAMD_UNIT_TEST_NUMTHREADS})
               add_test(NAME ${_target}_${_np}_${_thread} COMMAND
                 ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${_np} ${MPIEXEC_PREFLAGS}


### PR DESCRIPTION
Tests were mistakenly disabled in #51 due to capitalization change to match Kokkos