### PR TITLE
Use neighbor_parallel_for/reduce with LJ

### DIFF
--- a/src/cabanamd_impl.h
+++ b/src/cabanamd_impl.h
@@ -109,18 +109,23 @@ void CbnMD<t_System, t_Neighbor>::init( InputCL commandline )
     neighbor = new t_Neighbor( neigh_cutoff, half_neigh );
 
     // Create Force class: potential options in force_types/ folder
+    bool serial_neigh =
+        input->force_neigh_parallel_type == FORCE_PARALLEL_NEIGH_SERIAL;
+    bool team_neigh =
+        input->force_neigh_parallel_type == FORCE_PARALLEL_NEIGH_TEAM;
     if ( input->force_type == FORCE_LJ )
     {
-        force = new ForceLJ<t_System, t_Neighbor>( system );
+        if ( serial_neigh )
+            force = new ForceLJ<t_System, t_Neighbor, Cabana::SerialOpTag>(
+                system );
+        else if ( team_neigh )
+            force =
+                new ForceLJ<t_System, t_Neighbor, Cabana::TeamOpTag>( system );
     }
 #ifdef CabanaMD_ENABLE_NNP
 #include <system_nnp.h>
     else if ( input->force_type == FORCE_NNP )
     {
-        bool serial_neigh =
-            input->force_neigh_parallel_type == FORCE_PARALLEL_NEIGH_SERIAL;
-        bool team_neigh =
-            input->force_neigh_parallel_type == FORCE_PARALLEL_NEIGH_TEAM;
         bool vector_angle =
             input->force_neigh_parallel_type == FORCE_PARALLEL_NEIGH_VECTOR;
         if ( half_neigh )

--- a/src/force_types/force_lj_cabana_neigh.h
+++ b/src/force_types/force_lj_cabana_neigh.h
@@ -57,18 +57,13 @@
 #include <Cabana_Core.hpp>
 #include <Kokkos_Core.hpp>
 
-template <class t_System, class t_Neighbor>
+template <class t_System, class t_Neighbor, class t_parallel>
 class ForceLJ : public Force<t_System, t_Neighbor>
 {
   private:
     int N_local, ntypes;
-    typename t_System::t_x x;
-    typename t_System::t_f f;
-    typename t_System::t_f::atomic_access_slice f_a;
-    typename t_System::t_type type;
 
-    typedef typename t_Neighbor::t_neigh_list t_neigh_list;
-    typename t_Neighbor::t_neigh_list neigh_list;
+    typedef typename t_System::t_f::atomic_access_slice t_f_a;
 
     int step;
 
@@ -88,54 +83,25 @@ class ForceLJ : public Force<t_System, t_Neighbor>
     using exe_space = typename t_System::execution_space;
 
   public:
-    typedef T_V_FLOAT value_type;
-
-    struct TagFullNeigh
-    {
-    };
-
-    struct TagHalfNeigh
-    {
-    };
-
-    struct TagFullNeighPE
-    {
-    };
-
-    struct TagHalfNeighPE
-    {
-    };
-
-    typedef Kokkos::RangePolicy<exe_space, TagFullNeigh,
-                                Kokkos::IndexType<T_INT>>
-        t_policy_full_neigh_stackparams;
-    typedef Kokkos::RangePolicy<exe_space, TagHalfNeigh,
-                                Kokkos::IndexType<T_INT>>
-        t_policy_half_neigh_stackparams;
-    typedef Kokkos::RangePolicy<exe_space, TagFullNeighPE,
-                                Kokkos::IndexType<T_INT>>
-        t_policy_full_neigh_pe_stackparams;
-    typedef Kokkos::RangePolicy<exe_space, TagHalfNeighPE,
-                                Kokkos::IndexType<T_INT>>
-        t_policy_half_neigh_pe_stackparams;
-
     ForceLJ( t_System *system );
 
     void init_coeff( char **args ) override;
     void compute( t_System *system, t_Neighbor *neighbor ) override;
     T_F_FLOAT compute_energy( t_System *system, t_Neighbor *neighbor ) override;
 
-    KOKKOS_INLINE_FUNCTION
-    void operator()( TagFullNeigh, const T_INT &i ) const;
+    template <class t_f, class t_x, class t_type, class t_neigh>
+    void compute_force_full( t_f f, const t_x x, const t_type type,
+                             const t_neigh neigh_list );
+    template <class t_f, class t_x, class t_type, class t_neigh>
+    void compute_force_half( t_f f, const t_x x, const t_type type,
+                             const t_neigh neigh_list );
 
-    KOKKOS_INLINE_FUNCTION
-    void operator()( TagHalfNeigh, const T_INT &i ) const;
-
-    KOKKOS_INLINE_FUNCTION
-    void operator()( TagFullNeighPE, const T_INT &i, T_V_FLOAT &PE ) const;
-
-    KOKKOS_INLINE_FUNCTION
-    void operator()( TagHalfNeighPE, const T_INT &i, T_V_FLOAT &PE ) const;
+    template <class t_x, class t_type, class t_neigh>
+    T_F_FLOAT compute_energy_full( const t_x x, const t_type type,
+                                   const t_neigh neigh_list );
+    template <class t_x, class t_type, class t_neigh>
+    T_F_FLOAT compute_energy_half( const t_x x, const t_type type,
+                                   const t_neigh neigh_list );
 
     const char *name() override;
 };

--- a/src/force_types/force_lj_cabana_neigh_impl.h
+++ b/src/force_types/force_lj_cabana_neigh_impl.h
@@ -46,8 +46,8 @@
 //
 //************************************************************************
 
-template <class t_System, class t_Neighbor>
-ForceLJ<t_System, t_Neighbor>::ForceLJ( t_System *system )
+template <class t_System, class t_Neighbor, class t_parallel>
+ForceLJ<t_System, t_Neighbor, t_parallel>::ForceLJ( t_System *system )
     : Force<t_System, t_Neighbor>( system )
 {
     ntypes = system->ntypes;
@@ -60,8 +60,8 @@ ForceLJ<t_System, t_Neighbor>::ForceLJ( t_System *system )
     step = 0;
 }
 
-template <class t_System, class t_Neighbor>
-void ForceLJ<t_System, t_Neighbor>::init_coeff( char **args )
+template <class t_System, class t_Neighbor, class t_parallel>
+void ForceLJ<t_System, t_Neighbor, t_parallel>::init_coeff( char **args )
 {
     step = 0;
 
@@ -80,94 +80,81 @@ void ForceLJ<t_System, t_Neighbor>::init_coeff( char **args )
     }
 }
 
-template <class t_System, class t_Neighbor>
-void ForceLJ<t_System, t_Neighbor>::compute( t_System *system,
-                                             t_Neighbor *neighbor )
+template <class t_System, class t_Neighbor, class t_parallel>
+void ForceLJ<t_System, t_Neighbor, t_parallel>::compute( t_System *system,
+                                                         t_Neighbor *neighbor )
 {
     N_local = system->N_local;
     system->slice_force();
-    x = system->x;
-    f = system->f;
-    f_a = f;
-    type = system->type;
+    auto x = system->x;
+    auto f = system->f;
+    t_f_a f_a = system->f;
+    auto type = system->type;
 
-    neigh_list = neighbor->get();
+    auto neigh_list = neighbor->get();
 
     if ( neighbor->half_neigh )
     {
-        Kokkos::parallel_for(
-            "ForceLJCabanaNeigh::compute",
-            t_policy_half_neigh_stackparams( 0, system->N_local ), *this );
+        // Forces must be atomic for half list
+        compute_force_half( f_a, x, type, neigh_list );
     }
     else
     {
-        Kokkos::parallel_for(
-            "ForceLJCabanaNeigh::compute",
-            t_policy_full_neigh_stackparams( 0, system->N_local ), *this );
+        // Forces only atomic if using team threading
+        if ( std::is_same<t_parallel, Cabana::TeamOpTag>::value )
+            compute_force_full( f_a, x, type, neigh_list );
+        else
+            compute_force_full( f, x, type, neigh_list );
     }
     Kokkos::fence();
 
     step++;
 }
 
-template <class t_System, class t_Neighbor>
-T_V_FLOAT ForceLJ<t_System, t_Neighbor>::compute_energy( t_System *system,
-                                                         t_Neighbor *neighbor )
+template <class t_System, class t_Neighbor, class t_parallel>
+T_F_FLOAT ForceLJ<t_System, t_Neighbor, t_parallel>::compute_energy(
+    t_System *system, t_Neighbor *neighbor )
 {
     N_local = system->N_local;
     system->slice_force();
-    x = system->x;
-    f = system->f;
-    f_a = f;
-    type = system->type;
+    auto x = system->x;
+    auto f = system->f;
+    auto type = system->type;
 
-    neigh_list = neighbor->get();
+    auto neigh_list = neighbor->get();
 
-    T_V_FLOAT energy;
-
+    T_F_FLOAT energy;
     if ( neighbor->half_neigh )
-        Kokkos::parallel_reduce(
-            "ForceLJCabanaNeigh::compute_energy",
-            t_policy_half_neigh_pe_stackparams( 0, system->N_local ), *this,
-            energy );
+        energy = compute_energy_half( x, type, neigh_list );
     else
-        Kokkos::parallel_reduce(
-            "ForceLJCabanaNeigh::compute_energy",
-            t_policy_full_neigh_pe_stackparams( 0, system->N_local ), *this,
-            energy );
-
+        energy = compute_energy_full( x, type, neigh_list );
     Kokkos::fence();
 
     step++;
     return energy;
 }
 
-template <class t_System, class t_Neighbor>
-const char *ForceLJ<t_System, t_Neighbor>::name()
+template <class t_System, class t_Neighbor, class t_parallel>
+const char *ForceLJ<t_System, t_Neighbor, t_parallel>::name()
 {
     return "Force:LJCabana";
 }
 
-template <class t_System, class t_Neighbor>
-KOKKOS_INLINE_FUNCTION void ForceLJ<t_System, t_Neighbor>::
-operator()( TagFullNeigh, const T_INT &i ) const
+template <class t_System, class t_Neighbor, class t_parallel>
+template <class t_f, class t_x, class t_type, class t_neigh>
+void ForceLJ<t_System, t_Neighbor, t_parallel>::compute_force_full(
+    t_f f, const t_x x, const t_type type, const t_neigh neigh_list )
 {
-    const T_F_FLOAT x_i = x( i, 0 );
-    const T_F_FLOAT y_i = x( i, 1 );
-    const T_F_FLOAT z_i = x( i, 2 );
-    const int type_i = type( i );
-
-    int num_neighs =
-        Cabana::NeighborList<t_neigh_list>::numNeighbor( neigh_list, i );
-
-    T_F_FLOAT fxi = 0.0;
-    T_F_FLOAT fyi = 0.0;
-    T_F_FLOAT fzi = 0.0;
-
-    for ( int jj = 0; jj < num_neighs; jj++ )
+    auto force_full = KOKKOS_LAMBDA( const int i, const int j )
     {
-        int j = Cabana::NeighborList<t_neigh_list>::getNeighbor( neigh_list, i,
-                                                                 jj );
+        const T_F_FLOAT x_i = x( i, 0 );
+        const T_F_FLOAT y_i = x( i, 1 );
+        const T_F_FLOAT z_i = x( i, 2 );
+        const int type_i = type( i );
+
+        T_F_FLOAT fxi = 0.0;
+        T_F_FLOAT fyi = 0.0;
+        T_F_FLOAT fzi = 0.0;
 
         const T_F_FLOAT dx = x_i - x( j, 0 );
         const T_F_FLOAT dy = y_i - x( j, 1 );
@@ -190,32 +177,34 @@ operator()( TagFullNeigh, const T_INT &i ) const
             fyi += dy * fpair;
             fzi += dz * fpair;
         }
-    }
 
-    f( i, 0 ) += fxi;
-    f( i, 1 ) += fyi;
-    f( i, 2 ) += fzi;
+        f( i, 0 ) += fxi;
+        f( i, 1 ) += fyi;
+        f( i, 2 ) += fzi;
+    };
+
+    Kokkos::RangePolicy<exe_space> policy( 0, N_local );
+    t_parallel neigh_parallel;
+    Cabana::neighbor_parallel_for( policy, force_full, neigh_list,
+                                   Cabana::FirstNeighborsTag(), neigh_parallel,
+                                   "ForceLJCabanaNeigh::compute_full" );
 }
 
-template <class t_System, class t_Neighbor>
-KOKKOS_INLINE_FUNCTION void ForceLJ<t_System, t_Neighbor>::
-operator()( TagHalfNeigh, const T_INT &i ) const
+template <class t_System, class t_Neighbor, class t_parallel>
+template <class t_f, class t_x, class t_type, class t_neigh>
+void ForceLJ<t_System, t_Neighbor, t_parallel>::compute_force_half(
+    t_f f_a, const t_x x, const t_type type, const t_neigh neigh_list )
 {
-    const T_F_FLOAT x_i = x( i, 0 );
-    const T_F_FLOAT y_i = x( i, 1 );
-    const T_F_FLOAT z_i = x( i, 2 );
-    const int type_i = type( i );
-
-    int num_neighs =
-        Cabana::NeighborList<t_neigh_list>::numNeighbor( neigh_list, i );
-
-    T_F_FLOAT fxi = 0.0;
-    T_F_FLOAT fyi = 0.0;
-    T_F_FLOAT fzi = 0.0;
-    for ( int jj = 0; jj < num_neighs; jj++ )
+    auto force_half = KOKKOS_LAMBDA( const int i, const int j )
     {
-        int j = Cabana::NeighborList<t_neigh_list>::getNeighbor( neigh_list, i,
-                                                                 jj );
+        const T_F_FLOAT x_i = x( i, 0 );
+        const T_F_FLOAT y_i = x( i, 1 );
+        const T_F_FLOAT z_i = x( i, 2 );
+        const int type_i = type( i );
+
+        T_F_FLOAT fxi = 0.0;
+        T_F_FLOAT fyi = 0.0;
+        T_F_FLOAT fzi = 0.0;
 
         const T_F_FLOAT dx = x_i - x( j, 0 );
         const T_F_FLOAT dy = y_i - x( j, 1 );
@@ -241,29 +230,30 @@ operator()( TagHalfNeigh, const T_INT &i ) const
             f_a( j, 1 ) -= dy * fpair;
             f_a( j, 2 ) -= dz * fpair;
         }
-    }
-    f_a( i, 0 ) += fxi;
-    f_a( i, 1 ) += fyi;
-    f_a( i, 2 ) += fzi;
+        f_a( i, 0 ) += fxi;
+        f_a( i, 1 ) += fyi;
+        f_a( i, 2 ) += fzi;
+    };
+
+    Kokkos::RangePolicy<exe_space> policy( 0, N_local );
+    t_parallel neigh_parallel;
+    Cabana::neighbor_parallel_for( policy, force_half, neigh_list,
+                                   Cabana::FirstNeighborsTag(), neigh_parallel,
+                                   "ForceLJCabanaNeigh::compute_half" );
 }
 
-template <class t_System, class t_Neighbor>
-KOKKOS_INLINE_FUNCTION void ForceLJ<t_System, t_Neighbor>::
-operator()( TagFullNeighPE, const T_INT &i, T_V_FLOAT &PE ) const
+template <class t_System, class t_Neighbor, class t_parallel>
+template <class t_x, class t_type, class t_neigh>
+T_F_FLOAT ForceLJ<t_System, t_Neighbor, t_parallel>::compute_energy_full(
+    const t_x x, const t_type type, const t_neigh neigh_list )
 {
-    const T_F_FLOAT x_i = x( i, 0 );
-    const T_F_FLOAT y_i = x( i, 1 );
-    const T_F_FLOAT z_i = x( i, 2 );
-    const int type_i = type( i );
-    const bool shift_flag = true;
-
-    int num_neighs =
-        Cabana::NeighborList<t_neigh_list>::numNeighbor( neigh_list, i );
-
-    for ( int jj = 0; jj < num_neighs; jj++ )
+    auto energy_full = KOKKOS_LAMBDA( const int i, const int j, T_F_FLOAT &PE )
     {
-        int j = Cabana::NeighborList<t_neigh_list>::getNeighbor( neigh_list, i,
-                                                                 jj );
+        const T_F_FLOAT x_i = x( i, 0 );
+        const T_F_FLOAT y_i = x( i, 1 );
+        const T_F_FLOAT z_i = x( i, 2 );
+        const int type_i = type( i );
+        const bool shift_flag = true;
 
         const T_F_FLOAT dx = x_i - x( j, 0 );
         const T_F_FLOAT dy = y_i - x( j, 1 );
@@ -292,26 +282,30 @@ operator()( TagFullNeighPE, const T_INT &i, T_V_FLOAT &PE ) const
                       6.0; // optimize later
             }
         }
-    }
+    };
+
+    T_F_FLOAT energy = 0.0;
+    Kokkos::RangePolicy<exe_space> policy( 0, N_local );
+    t_parallel neigh_parallel;
+    Cabana::neighbor_parallel_reduce(
+        policy, energy_full, neigh_list, Cabana::FirstNeighborsTag(),
+        neigh_parallel, energy, "ForceLJCabanaNeigh::compute_half" );
+    return energy;
 }
 
-template <class t_System, class t_Neighbor>
-KOKKOS_INLINE_FUNCTION void ForceLJ<t_System, t_Neighbor>::
-operator()( TagHalfNeighPE, const T_INT &i, T_V_FLOAT &PE ) const
+template <class t_System, class t_Neighbor, class t_parallel>
+template <class t_x, class t_type, class t_neigh>
+T_F_FLOAT ForceLJ<t_System, t_Neighbor, t_parallel>::compute_energy_half(
+    const t_x x, const t_type type, const t_neigh neigh_list )
 {
-    const T_F_FLOAT x_i = x( i, 0 );
-    const T_F_FLOAT y_i = x( i, 1 );
-    const T_F_FLOAT z_i = x( i, 2 );
-    const int type_i = type( i );
-    const bool shift_flag = true;
-
-    int num_neighs =
-        Cabana::NeighborList<t_neigh_list>::numNeighbor( neigh_list, i );
-
-    for ( int jj = 0; jj < num_neighs; jj++ )
+    auto energy_half = KOKKOS_LAMBDA( const int i, const int j, T_F_FLOAT &PE )
     {
-        int j = Cabana::NeighborList<t_neigh_list>::getNeighbor( neigh_list, i,
-                                                                 jj );
+
+        const T_F_FLOAT x_i = x( i, 0 );
+        const T_F_FLOAT y_i = x( i, 1 );
+        const T_F_FLOAT z_i = x( i, 2 );
+        const int type_i = type( i );
+        const bool shift_flag = true;
 
         const T_F_FLOAT dx = x_i - x( j, 0 );
         const T_F_FLOAT dy = y_i - x( j, 1 );
@@ -346,5 +340,13 @@ operator()( TagHalfNeighPE, const T_INT &i, T_V_FLOAT &PE ) const
                       6.0; // optimize later
             }
         }
-    }
+    };
+
+    T_F_FLOAT energy = 0.0;
+    Kokkos::RangePolicy<exe_space> policy( 0, N_local );
+    t_parallel neigh_parallel;
+    Cabana::neighbor_parallel_reduce(
+        policy, energy_half, neigh_list, Cabana::FirstNeighborsTag(),
+        neigh_parallel, energy, "ForceLJCabanaNeigh::compute_half" );
+    return energy;
 }


### PR DESCRIPTION
This uses the `neighbor_parallel_for` and `neighbor_parallel_reduce` to simplify and provide flexibility for the LJ kernel. 

This also changes LJ from class functors to lambdas, which removed a lot of member variables

Closes #23 