### PR TITLE
Fix typo "CabanaMD_ENABLE_ARBORX => Cabana_ENABLE_ARBORX"

### DIFF
--- a/src/mdfactory.h
+++ b/src/mdfactory.h
@@ -580,7 +580,7 @@ class MDfactory
                         return new CbnMD<t_sys, t_neigh>;
                     }
                 }
-#ifdef CabanaMD_ENABLE_ARBORX
+#ifdef Cabana_ENABLE_ARBORX
                 else if ( neigh == NEIGH_TREE )
                 {
                     using t_lay = Cabana::VerletLayoutCSR;
@@ -634,7 +634,7 @@ class MDfactory
                         return new CbnMD<t_sys, t_neigh>;
                     }
                 }
-#ifdef CabanaMD_ENABLE_ARBORX
+#ifdef Cabana_ENABLE_ARBORX
                 else if ( neigh == NEIGH_TREE )
                 {
                     using t_lay = Cabana::VerletLayoutCSR;
@@ -688,7 +688,7 @@ class MDfactory
                         return new CbnMD<t_sys, t_neigh>;
                     }
                 }
-#ifdef CabanaMD_ENABLE_ARBORX
+#ifdef Cabana_ENABLE_ARBORX
                 else if ( neigh == NEIGH_TREE )
                 {
                     using t_lay = Cabana::VerletLayoutCSR;

--- a/unit_test/tstNeighbor.hpp
+++ b/unit_test/tstNeighbor.hpp
@@ -338,7 +338,7 @@ TEST( TEST_CATEGORY, verlet_full_test )
         testNeighborListPartialRange<t_System, t_Neigh>( false );
     }
     {
-#ifdef CabanaMD_ENABLE_ARBORX
+#ifdef Cabana_ENABLE_ARBORX
         using t_Neigh = NeighborTree<t_System, Cabana::FullNeighborTag,
                                      Cabana::VerletLayoutCSR>;
         testNeighborListPartialRange<t_System, t_Neigh>( false );
@@ -362,7 +362,7 @@ TEST( TEST_CATEGORY, verlet_half_test )
         testNeighborListPartialRange<t_System, t_Neigh>( true );
     }
     {
-#ifdef CabanaMD_ENABLE_ARBORX
+#ifdef Cabana_ENABLE_ARBORX
         using t_Neigh = NeighborTree<t_System, Cabana::HalfNeighborTag,
                                      Cabana::VerletLayoutCSR>;
         testNeighborListPartialRange<t_System, t_Neigh>( true );


### PR DESCRIPTION
I am still looking at resolving issues with `#include`s order but I see no reason to delay that obvious fix