### PR TITLE
Do not explicitly link against dl and hwloc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,7 +65,7 @@ target_include_directories(CabanaMD PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
 
 #------------------------------------------------------------
 
-target_link_libraries(CabanaMD Cabana::cabanacore dl hwloc)
+target_link_libraries(CabanaMD Cabana::cabanacore)
 
 if(CabanaMD_ENABLE_NNP AND N2P2_DIR)
   target_include_directories(CabanaMD PUBLIC ${N2P2_DIR}/include)


### PR DESCRIPTION
I am not sure why these were there in the first place.