### PR TITLE
Convert LJ parameter arrays to Views

### DIFF
--- a/src/force_types/force_lj_cabana_neigh.h
+++ b/src/force_types/force_lj_cabana_neigh.h
@@ -64,20 +64,13 @@ class ForceLJ : public Force<t_System, t_Neighbor>
 
     int step;
 
-    typedef Kokkos::View<T_F_FLOAT **> t_fparams;
-    typedef Kokkos::View<const T_F_FLOAT **,
-                         Kokkos::MemoryTraits<Kokkos::RandomAccess>>
-        t_fparams_rnd;
-    t_fparams lj1, lj2, cutsq;
-    t_fparams_rnd rnd_lj1, rnd_lj2, rnd_cutsq;
-
-    T_F_FLOAT stack_lj1[MAX_TYPES_STACKPARAMS + 1]
-                       [MAX_TYPES_STACKPARAMS +
-                        1]; // hardwired space for 12 atom types
-    T_F_FLOAT stack_lj2[MAX_TYPES_STACKPARAMS + 1][MAX_TYPES_STACKPARAMS + 1];
-    T_F_FLOAT stack_cutsq[MAX_TYPES_STACKPARAMS + 1][MAX_TYPES_STACKPARAMS + 1];
-
     using exe_space = typename t_System::execution_space;
+    using mem_space = typename t_System::memory_space;
+
+    typedef Kokkos::View<T_F_FLOAT **, mem_space,
+                         Kokkos::MemoryTraits<Kokkos::RandomAccess>>
+        t_fparams;
+    t_fparams lj1, lj2, cutsq;
 
   public:
     ForceLJ( t_System *system );

--- a/src/types.h
+++ b/src/types.h
@@ -148,8 +148,6 @@ enum
 #define MAX( a, b ) ( a > b ? a : b )
 #define MIN( a, b ) ( a < b ? a : b )
 
-#define MAX_TYPES_STACKPARAMS 12
-
 // Define Scalar Types
 #ifndef T_INT
 #define T_INT int


### PR DESCRIPTION
Use Kokkos::View for all LJ force parameters, rather than fixed-size arrays. 

Gives a slight speed-up. 