### PR TITLE
Add default Kokkos backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,18 +41,6 @@ if( NOT Cabana_ENABLE_MPI )
   message( FATAL_ERROR "Cabana must be compiled with MPI" )
 endif()
 
-option(CabanaMD_REQUIRE_SERIAL "Build CabanaMD with Serial support" ON)
-option(CabanaMD_REQUIRE_OPENMP "Build CabanaMD with OpenMP support" OFF)
-option(CabanaMD_REQUIRE_CUDA "Build CabanaMD with Cuda support" OFF)
-option(CabanaMD_REQUIRE_HIP "Build CabanaMD with HIP support" OFF)
-
-set(CABANAMD_SUPPORTED_DEVICES SERIAL OPENMP CUDA HIP)
-foreach(_device ${CABANAMD_SUPPORTED_DEVICES})
-  if(CabanaMD_REQUIRE_${_device})
-    kokkos_check( DEVICES ${_device} )
-  endif()
-endforeach()
-
 ##---------------------------------------------------------------------------##
 # Set up optional libraries
 ##---------------------------------------------------------------------------##

--- a/src/inputCL.cpp
+++ b/src/inputCL.cpp
@@ -56,7 +56,7 @@
 
 InputCL::InputCL()
 {
-    device_type = SERIAL;
+    device_type = DEFAULT;
     layout_type = AOSOA_6;
     nnp_layout_type = AOSOA_3;
     neighbor_type = NEIGH_VERLET_2D;

--- a/src/mdfactory.h
+++ b/src/mdfactory.h
@@ -30,11 +30,20 @@ class MDfactory
         bool half_neigh =
             commandline.force_iteration_type == FORCE_ITER_NEIGH_HALF;
 
+        if ( device == CUDA )
+        {
+            // Cuda is the first default, so just use that.
+            device = DEFAULT;
+#ifndef KOKKOS_ENABLE_CUDA
+            throw std::runtime_error(
+                "CabanaMD not compiled with Kokkos::Cuda" );
+#endif // Cuda
+        }
         if ( device == DEFAULT )
         {
-	    using t_exe = Kokkos::DefaultExecutionSpace;
-	    using t_mem = typename t_exe::memory_space;
-	    using t_device = Kokkos::Device<t_exe, t_mem>;
+            using t_exe = Kokkos::DefaultExecutionSpace;
+            using t_mem = typename t_exe::memory_space;
+            using t_device = Kokkos::Device<t_exe, t_mem>;
             if ( layout == AOSOA_1 )
             {
                 using t_sys = System<t_device, AoSoA1>;
@@ -683,225 +692,6 @@ class MDfactory
             throw std::runtime_error(
                 "CabanaMD not compiled with Kokkos::OpenMP" );
 #endif // OpenMP
-        }
-        else if ( device == CUDA )
-        {
-#ifdef KOKKOS_ENABLE_CUDA
-            using t_device = Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>;
-            if ( layout == AOSOA_1 )
-            {
-                using t_sys = System<t_device, AoSoA1>;
-                if ( neigh == NEIGH_VERLET_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_VERLET_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#ifdef Cabana_ENABLE_ARBORX
-                else if ( neigh == NEIGH_TREE_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_TREE_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#endif // ArborX
-            }
-            else if ( layout == AOSOA_2 )
-            {
-                using t_sys = System<t_device, AoSoA2>;
-                if ( neigh == NEIGH_VERLET_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_VERLET_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#ifdef Cabana_ENABLE_ARBORX
-                else if ( neigh == NEIGH_TREE_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_TREE_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#endif // ArborX
-            }
-            else if ( layout == AOSOA_6 )
-            {
-                using t_sys = System<t_device, AoSoA6>;
-                if ( neigh == NEIGH_VERLET_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_VERLET_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#ifdef Cabana_ENABLE_ARBORX
-                else if ( neigh == NEIGH_TREE_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_TREE_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#endif // ArborX
-            }
-#else
-            throw std::runtime_error(
-                "CabanaMD not compiled with Kokkos::Cuda" );
-#endif // Cuda
         }
         else if ( device == HIP )
         {

--- a/src/mdfactory.h
+++ b/src/mdfactory.h
@@ -30,6 +30,222 @@ class MDfactory
         bool half_neigh =
             commandline.force_iteration_type == FORCE_ITER_NEIGH_HALF;
 
+        if ( device == DEFAULT )
+        {
+	    using t_exe = Kokkos::DefaultExecutionSpace;
+	    using t_mem = typename t_exe::memory_space;
+	    using t_device = Kokkos::Device<t_exe, t_mem>;
+            if ( layout == AOSOA_1 )
+            {
+                using t_sys = System<t_device, AoSoA1>;
+                if ( neigh == NEIGH_VERLET_2D )
+                {
+                    using t_lay = Cabana::VerletLayout2D;
+                    if ( half_neigh )
+                    {
+                        using t_half = Cabana::HalfNeighborTag;
+                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                    else
+                    {
+                        using t_full = Cabana::FullNeighborTag;
+                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                }
+                else if ( neigh == NEIGH_VERLET_CSR )
+                {
+                    using t_lay = Cabana::VerletLayoutCSR;
+                    if ( half_neigh )
+                    {
+                        using t_half = Cabana::HalfNeighborTag;
+                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                    else
+                    {
+                        using t_full = Cabana::FullNeighborTag;
+                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                }
+#ifdef Cabana_ENABLE_ARBORX
+                else if ( neigh == NEIGH_TREE_2D )
+                {
+                    using t_lay = Cabana::VerletLayout2D;
+                    if ( half_neigh )
+                    {
+                        using t_half = Cabana::HalfNeighborTag;
+                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                    else
+                    {
+                        using t_full = Cabana::FullNeighborTag;
+                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                }
+                else if ( neigh == NEIGH_TREE_CSR )
+                {
+                    using t_lay = Cabana::VerletLayoutCSR;
+                    if ( half_neigh )
+                    {
+                        using t_half = Cabana::HalfNeighborTag;
+                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                    else
+                    {
+                        using t_full = Cabana::FullNeighborTag;
+                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                }
+#endif // ArborX
+            }
+            else if ( layout == AOSOA_2 )
+            {
+                using t_sys = System<t_device, AoSoA2>;
+                if ( neigh == NEIGH_VERLET_2D )
+                {
+                    using t_lay = Cabana::VerletLayout2D;
+                    if ( half_neigh )
+                    {
+                        using t_half = Cabana::HalfNeighborTag;
+                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                    else
+                    {
+                        using t_full = Cabana::FullNeighborTag;
+                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                }
+                else if ( neigh == NEIGH_VERLET_CSR )
+                {
+                    using t_lay = Cabana::VerletLayoutCSR;
+                    if ( half_neigh )
+                    {
+                        using t_half = Cabana::HalfNeighborTag;
+                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                    else
+                    {
+                        using t_full = Cabana::FullNeighborTag;
+                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                }
+#ifdef Cabana_ENABLE_ARBORX
+                else if ( neigh == NEIGH_TREE_2D )
+                {
+                    using t_lay = Cabana::VerletLayout2D;
+                    if ( half_neigh )
+                    {
+                        using t_half = Cabana::HalfNeighborTag;
+                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                    else
+                    {
+                        using t_full = Cabana::FullNeighborTag;
+                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                }
+                else if ( neigh == NEIGH_TREE_CSR )
+                {
+                    using t_lay = Cabana::VerletLayoutCSR;
+                    if ( half_neigh )
+                    {
+                        using t_half = Cabana::HalfNeighborTag;
+                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                    else
+                    {
+                        using t_full = Cabana::FullNeighborTag;
+                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                }
+#endif // ArborX
+            }
+            else if ( layout == AOSOA_6 )
+            {
+                using t_sys = System<t_device, AoSoA6>;
+                if ( neigh == NEIGH_VERLET_2D )
+                {
+                    using t_lay = Cabana::VerletLayout2D;
+                    if ( half_neigh )
+                    {
+                        using t_half = Cabana::HalfNeighborTag;
+                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                    else
+                    {
+                        using t_full = Cabana::FullNeighborTag;
+                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                }
+                else if ( neigh == NEIGH_VERLET_CSR )
+                {
+                    using t_lay = Cabana::VerletLayoutCSR;
+                    if ( half_neigh )
+                    {
+                        using t_half = Cabana::HalfNeighborTag;
+                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                    else
+                    {
+                        using t_full = Cabana::FullNeighborTag;
+                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                }
+#ifdef Cabana_ENABLE_ARBORX
+                else if ( neigh == NEIGH_TREE_2D )
+                {
+                    using t_lay = Cabana::VerletLayout2D;
+                    if ( half_neigh )
+                    {
+                        using t_half = Cabana::HalfNeighborTag;
+                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                    else
+                    {
+                        using t_full = Cabana::FullNeighborTag;
+                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                }
+                else if ( neigh == NEIGH_TREE_CSR )
+                {
+                    using t_lay = Cabana::VerletLayoutCSR;
+                    if ( half_neigh )
+                    {
+                        using t_half = Cabana::HalfNeighborTag;
+                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                    else
+                    {
+                        using t_full = Cabana::FullNeighborTag;
+                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
+                        return new CbnMD<t_sys, t_neigh>;
+                    }
+                }
+#endif // ArborX
+            }
+        }
         if ( device == SERIAL )
         {
 #ifdef KOKKOS_ENABLE_SERIAL

--- a/src/types.h
+++ b/src/types.h
@@ -64,7 +64,8 @@ enum
     CUDA,
     HIP,
     OPENMP,
-    SERIAL
+    SERIAL,
+    DEFAULT
 };
 
 // AoSoA layout type


### PR DESCRIPTION
Enable using the default Kokkos backend, keeping the command line options for serial, OpenMP, Cuda (always default), and HIP.