### PR TITLE
Enable user preallocation for Verlet neighbor lists

### DIFF
--- a/input/in.lj
+++ b/input/in.lj
@@ -16,7 +16,7 @@ pair_style	lj/cut 2.5
 pair_coeff	1 1 1.0 1.0 2.5
 
 neighbor	0.3 bin
-neigh_modify delay 0 every 20 check no
+neigh_modify	every 20 one 50
 fix		1 all nve
 thermo 10
 

--- a/src/cabanamd_impl.h
+++ b/src/cabanamd_impl.h
@@ -110,7 +110,8 @@ void CbnMD<t_System, t_Neighbor>::init( InputCL commandline )
     binning = new Binning<t_System>( system );
 
     // Create Neighbor class: create neighbor list
-    neighbor = new t_Neighbor( neigh_cutoff, half_neigh );
+    neighbor =
+        new t_Neighbor( neigh_cutoff, half_neigh, input->max_neigh_guess );
 
     // Create Force class: potential options in force_types/ folder
     bool serial_neigh =

--- a/src/inputFile.h
+++ b/src/inputFile.h
@@ -188,6 +188,7 @@ class InputFile
 
     T_F_FLOAT neighbor_skin;
     int neighbor_type;
+    T_INT max_neigh_guess;
 
     int layout_type;
     int nnp_layout_type;

--- a/src/inputFile_impl.h
+++ b/src/inputFile_impl.h
@@ -119,6 +119,7 @@ InputFile<t_System>::InputFile( InputCL commandline_, t_System *system_ )
 
     neighbor_skin = 0.3;
     neighbor_skin = 0.0; // for metal and real units
+    max_neigh_guess = 50;
     comm_exchange_rate = 20;
 
     force_cutoff = 2.5;
@@ -392,11 +393,25 @@ void InputFile<t_System>::check_lammps_command( std::string line,
     if ( keyword.compare( "neigh_modify" ) == 0 )
     {
         known = true;
-        for ( std::size_t i = 0; i < words.size(); i++ )
+        std::size_t i = 1;
+        while ( i < words.size() )
+        {
             if ( words.at( i ).compare( "every" ) == 0 )
             {
                 comm_exchange_rate = std::stoi( words.at( i + 1 ) );
+                i += 2;
             }
+            else if ( words.at( i ).compare( "one" ) == 0 )
+            {
+                max_neigh_guess = std::stoi( words.at( i + 1 ) );
+                i += 2;
+            }
+            else
+            {
+                log_err( err, "LAMMPS-Command: 'neigh_modify' only supports "
+                              "'every' and 'one' in CabanaMD" );
+            }
+        }
     }
     if ( keyword.compare( "fix" ) == 0 )
     {

--- a/src/neighbor.h
+++ b/src/neighbor.h
@@ -57,11 +57,14 @@ class Neighbor
   public:
     T_X_FLOAT neigh_cut;
     bool half_neigh;
+    T_INT max_neigh_guess;
 
     Neighbor();
-    Neighbor( T_X_FLOAT neigh_cut_, bool half_neigh_ )
+    Neighbor( T_X_FLOAT neigh_cut_, bool half_neigh_,
+              T_INT max_neigh_guess_ = 0 )
         : neigh_cut( neigh_cut_ )
         , half_neigh( half_neigh_ )
+        , max_neigh_guess( max_neigh_guess_ )
     {
     }
     virtual ~Neighbor() {}

--- a/src/neighbor_types/neighbor_tree.h
+++ b/src/neighbor_types/neighbor_tree.h
@@ -35,7 +35,7 @@ class NeighborTree<t_System, t_iteration, Cabana::VerletLayoutCSR>
     using t_neigh_list =
         Cabana::Experimental::CrsGraph<memory_space, t_iteration>;
 
-    NeighborTree( T_X_FLOAT neigh_cut_, bool half_neigh_ )
+    NeighborTree( T_X_FLOAT neigh_cut_, bool half_neigh_, T_INT )
         : Neighbor<t_System>( neigh_cut_, half_neigh_ )
         , neigh_cut( neigh_cut_ )
         , half_neigh( half_neigh_ )
@@ -79,7 +79,7 @@ class NeighborTree<t_System, t_iteration, Cabana::VerletLayout2D>
 
     using t_neigh_list = Cabana::Experimental::Dense<memory_space, t_iteration>;
 
-    NeighborTree( T_X_FLOAT neigh_cut_, bool half_neigh_ )
+    NeighborTree( T_X_FLOAT neigh_cut_, bool half_neigh_, T_INT )
         : Neighbor<t_System>( neigh_cut_, half_neigh_ )
         , neigh_cut( neigh_cut_ )
         , half_neigh( half_neigh_ )

--- a/src/neighbor_types/neighbor_verlet.h
+++ b/src/neighbor_types/neighbor_verlet.h
@@ -25,7 +25,7 @@ class NeighborVerlet : public Neighbor<t_System>
   public:
     T_X_FLOAT neigh_cut;
     bool half_neigh;
-    T_INT max_neigh = 50;
+    T_INT max_neigh_guess;
 
 #ifdef KOKKOS_ENABLE_HIP
     using t_build = Cabana::TeamOpTag;
@@ -35,10 +35,12 @@ class NeighborVerlet : public Neighbor<t_System>
     using t_neigh_list =
         Cabana::VerletList<memory_space, t_iteration, t_layout, t_build>;
 
-    NeighborVerlet( T_X_FLOAT neigh_cut_, bool half_neigh_ )
-        : Neighbor<t_System>( neigh_cut_, half_neigh_ )
+    NeighborVerlet( T_X_FLOAT neigh_cut_, bool half_neigh_,
+                    T_INT max_neigh_guess_ )
+        : Neighbor<t_System>( neigh_cut_, half_neigh_, max_neigh_guess_ )
         , neigh_cut( neigh_cut_ )
         , half_neigh( half_neigh_ )
+        , max_neigh_guess( max_neigh_guess_ )
     {
     }
 
@@ -57,8 +59,8 @@ class NeighborVerlet : public Neighbor<t_System>
         auto x = system->x;
 
         list = t_neigh_list( x, 0, N_local, neigh_cut, 1.0, grid_min, grid_max,
-                             max_neigh );
-        max_neigh =
+                             max_neigh_guess );
+        max_neigh_guess =
             Cabana::NeighborList<t_neigh_list>::maxNeighbor( list ) * 1.1;
     }
 

--- a/unit_test/tstNeighbor.hpp
+++ b/unit_test/tstNeighbor.hpp
@@ -304,7 +304,7 @@ void testNeighborListPartialRange( bool half_neigh )
         createAtoms<t_System>( num_atom, num_ghost, box_min, box_max );
 
     // Create the neighbor list.
-    t_Neighbor neighbor( cutoff, half_neigh );
+    t_Neighbor neighbor( cutoff, half_neigh, 100 );
     neighbor.create( &system );
 
     // Check the neighbor list.


### PR DESCRIPTION
Expose the option to preallocate maximum neighbors per atom in Cabana and fully support in the input file. Currently only for Verlet, but easy to add for ArborX as well once implemented. 