### PR TITLE
Fix NNP errors with Cuda

### DIFF
--- a/src/force_types/nnp_element_impl.h
+++ b/src/force_types/nnp_element_impl.h
@@ -312,8 +312,9 @@ void Element::setupSymmetryFunctionGroups( t_SF SF,
                                            h_t_int h_numSFGperElem,
                                            int maxSFperElem )
 {
-    h_t_int h_numGR( "RadialCounter", h_numSFGperElem.extent( 0 ) );
-    h_t_int h_numGA( "AngularCounter", h_numSFGperElem.extent( 0 ) );
+    int num_group = h_numSFperElem.extent( 0 ) * 2;
+    h_t_int h_numGR( "RadialCounter", num_group );
+    h_t_int h_numGA( "AngularCounter", num_group );
     int SFindex;
     for ( int k = 0; k < h_numSFperElem( attype ); ++k )
     {
@@ -365,16 +366,14 @@ void Element::setupSymmetryFunctionGroups( t_SF SF,
             h_numSFGperElem( attype )++;
             if ( SF( attype, SFindex, 1 ) == 2 )
             {
-                h_numGR( l ) = 0;
-                SFGmemberlist( attype, l, h_numGR( l ) ) = SFindex;
-                h_numGR( l )++;
+                SFGmemberlist( attype, l, 0 ) = SFindex;
+                h_numGR( l ) = 1;
                 SFGmemberlist( attype, l, maxSFperElem )++;
             }
             else if ( SF( attype, SFindex, 1 ) == 3 )
             {
-                h_numGA( l ) = 0;
-                SFGmemberlist( attype, l, h_numGA( l ) ) = SFindex;
-                h_numGA( l )++;
+                SFGmemberlist( attype, l, 0 ) = SFindex;
+                h_numGA( l ) = 1;
                 SFGmemberlist( attype, l, maxSFperElem )++;
             }
         }

--- a/src/force_types/nnp_mode.h
+++ b/src/force_types/nnp_mode.h
@@ -346,8 +346,9 @@ public:
   std::vector<std::size_t> numAtomsPerElement;
 
   KOKKOS_INLINE_FUNCTION
-  void compute_cutoff(CutoffFunction::CutoffType cutoffType, double &fc,
-                      double &dfc, double r, double rc, bool derivative);
+  void compute_cutoff(CutoffFunction::CutoffType cutoffType, double cutoffAlpha,
+                      double &fc, double &dfc, double r, double rc,
+                      bool derivative);
 
   KOKKOS_INLINE_FUNCTION
   double scale(int attype, double value, int k, d_t_SFscaling SFscaling);
@@ -466,8 +467,8 @@ template <class t_device> inline bool Mode<t_device>::useNormalization() const {
 template <class t_device>
 KOKKOS_INLINE_FUNCTION void
 Mode<t_device>::compute_cutoff(CutoffFunction::CutoffType cutoffType,
-                               double &fc, double &dfc, double r, double rc,
-                               bool derivative) {
+                               double cutoffAlpha, double &fc, double &dfc,
+                               double r, double rc, bool derivative) {
   double temp;
   if (cutoffType == CutoffFunction::CT_TANHU) {
     temp = tanh(1.0 - r / rc);
@@ -496,15 +497,15 @@ Mode<t_device>::compute_cutoff(CutoffFunction::CutoffType cutoffType,
 template <class t_device>
 KOKKOS_INLINE_FUNCTION double Mode<t_device>::scale(int attype, double value,
                                                     int k,
-                                                    d_t_SFscaling SFscaling) {
-  double scalingType = SFscaling(attype, k, 7);
-  double scalingFactor = SFscaling(attype, k, 6);
-  double Gmin = SFscaling(attype, k, 0);
-  // double Gmax = SFscaling(attype,k,1);
-  double Gmean = SFscaling(attype, k, 2);
-  // double Gsigma = SFscaling(attype,k,3);
-  double Smin = SFscaling(attype, k, 4);
-  // double Smax = SFscaling(attype,k,5);
+                                                    d_t_SFscaling SFscaling_) {
+  double scalingType = SFscaling_(attype, k, 7);
+  double scalingFactor = SFscaling_(attype, k, 6);
+  double Gmin = SFscaling_(attype, k, 0);
+  // double Gmax = SFscaling_(attype,k,1);
+  double Gmean = SFscaling_(attype, k, 2);
+  // double Gsigma = SFscaling_(attype,k,3);
+  double Smin = SFscaling_(attype, k, 4);
+  // double Smax = SFscaling_(attype,k,5);
 
   if (scalingType == 0.0) {
     return value;

--- a/src/force_types/nnp_mode.h
+++ b/src/force_types/nnp_mode.h
@@ -348,10 +348,10 @@ public:
   KOKKOS_INLINE_FUNCTION
   void compute_cutoff(CutoffFunction::CutoffType cutoffType, double cutoffAlpha,
                       double &fc, double &dfc, double r, double rc,
-                      bool derivative);
+                      bool derivative) const;
 
   KOKKOS_INLINE_FUNCTION
-  double scale(int attype, double value, int k, d_t_SFscaling SFscaling);
+  double scale(int attype, double value, int k, d_t_SFscaling SFscaling) const;
 
   template <class t_slice_x, class t_slice_f, class t_slice_type,
             class t_slice_dEdG, class t_neigh_list, class t_neigh_parallel,
@@ -468,7 +468,7 @@ template <class t_device>
 KOKKOS_INLINE_FUNCTION void
 Mode<t_device>::compute_cutoff(CutoffFunction::CutoffType cutoffType,
                                double cutoffAlpha, double &fc, double &dfc,
-                               double r, double rc, bool derivative) {
+                               double r, double rc, bool derivative) const {
   double temp;
   if (cutoffType == CutoffFunction::CT_TANHU) {
     temp = tanh(1.0 - r / rc);
@@ -495,9 +495,9 @@ Mode<t_device>::compute_cutoff(CutoffFunction::CutoffType cutoffType,
 }
 
 template <class t_device>
-KOKKOS_INLINE_FUNCTION double Mode<t_device>::scale(int attype, double value,
-                                                    int k,
-                                                    d_t_SFscaling SFscaling_) {
+KOKKOS_INLINE_FUNCTION double
+Mode<t_device>::scale(int attype, double value, int k,
+                      d_t_SFscaling SFscaling_) const {
   double scalingType = SFscaling_(attype, k, 7);
   double scalingFactor = SFscaling_(attype, k, 6);
   double Gmin = SFscaling_(attype, k, 0);

--- a/src/force_types/nnp_mode_impl.h
+++ b/src/force_types/nnp_mode_impl.h
@@ -858,6 +858,15 @@ void Mode<t_device>::calculateSymmetryFunctionGroups(
 
     Kokkos::RangePolicy<exe_space> policy( 0, N_local );
 
+    // Create local copies for lambda
+    auto numSFGperElem_ = numSFGperElem;
+    auto SFGmemberlist_ = d_SFGmemberlist;
+    auto SF_ = d_SF;
+    auto SFscaling_ = d_SFscaling;
+    auto maxSFperElem_ = maxSFperElem;
+    auto convLength_ = convLength;
+    auto cutoffType_ = cutoffType;
+
     auto calc_radial_symm_op = KOKKOS_LAMBDA( const int i, const int j )
     {
         double pfcij = 0.0;
@@ -869,33 +878,34 @@ void Mode<t_device>::calculateSymmetryFunctionGroups(
         T_F_FLOAT dxij, dyij, dzij;
 
         int attype = type( i );
-        for ( int groupIndex = 0; groupIndex < numSFGperElem( attype );
+        for ( int groupIndex = 0; groupIndex < numSFGperElem_( attype );
               ++groupIndex )
         {
-            if ( d_SF( attype, d_SFGmemberlist( attype, groupIndex, 0 ), 1 ) ==
+            if ( SF_( attype, SFGmemberlist_( attype, groupIndex, 0 ), 1 ) ==
                  2 )
             {
-                size_t memberindex0 = d_SFGmemberlist( attype, groupIndex, 0 );
-                size_t e1 = d_SF( attype, memberindex0, 2 );
-                double rc = d_SF( attype, memberindex0, 7 );
+                size_t memberindex0 = SFGmemberlist_( attype, groupIndex, 0 );
+                size_t e1 = SF_( attype, memberindex0, 2 );
+                double rc = SF_( attype, memberindex0, 7 );
                 size_t size =
-                    d_SFGmemberlist( attype, groupIndex, maxSFperElem );
+                    SFGmemberlist_( attype, groupIndex, maxSFperElem_ );
 
                 nej = type( j );
-                dxij = ( x( i, 0 ) - x( j, 0 ) ) * CFLENGTH * convLength;
-                dyij = ( x( i, 1 ) - x( j, 1 ) ) * CFLENGTH * convLength;
-                dzij = ( x( i, 2 ) - x( j, 2 ) ) * CFLENGTH * convLength;
+                dxij = ( x( i, 0 ) - x( j, 0 ) ) * CFLENGTH * convLength_;
+                dyij = ( x( i, 1 ) - x( j, 1 ) ) * CFLENGTH * convLength_;
+                dzij = ( x( i, 2 ) - x( j, 2 ) ) * CFLENGTH * convLength_;
                 r2ij = dxij * dxij + dyij * dyij + dzij * dzij;
                 rij = sqrt( r2ij );
                 if ( e1 == nej && rij < rc )
                 {
-                    compute_cutoff( cutoffType, pfcij, pdfcij, rij, rc, false );
+                    compute_cutoff( cutoffType_, pfcij, pdfcij, rij, rc,
+                                    false );
                     for ( size_t k = 0; k < size; ++k )
                     {
-                        memberindex = d_SFGmemberlist( attype, groupIndex, k );
-                        globalIndex = d_SF( attype, memberindex, 14 );
-                        eta = d_SF( attype, memberindex, 4 );
-                        rs = d_SF( attype, memberindex, 8 );
+                        memberindex = SFGmemberlist_( attype, groupIndex, k );
+                        globalIndex = SF_( attype, memberindex, 14 );
+                        eta = SF_( attype, memberindex, 4 );
+                        rs = SF_( attype, memberindex, 8 );
                         G( i, globalIndex ) +=
                             exp( -eta * ( rij - rs ) * ( rij - rs ) ) * pfcij;
                     }
@@ -921,29 +931,30 @@ void Mode<t_device>::calculateSymmetryFunctionGroups(
         double eta, rs, lambda, zeta;
 
         int attype = type( i );
-        for ( int groupIndex = 0; groupIndex < numSFGperElem( attype );
+        for ( int groupIndex = 0; groupIndex < numSFGperElem_( attype );
               ++groupIndex )
         {
-            if ( d_SF( attype, d_SFGmemberlist( attype, groupIndex, 0 ), 1 ) ==
+            if ( SF_( attype, SFGmemberlist_( attype, groupIndex, 0 ), 1 ) ==
                  3 )
             {
-                size_t memberindex0 = d_SFGmemberlist( attype, groupIndex, 0 );
-                size_t e1 = d_SF( attype, memberindex0, 2 );
-                size_t e2 = d_SF( attype, memberindex0, 3 );
-                double rc = d_SF( attype, memberindex0, 7 );
+                size_t memberindex0 = SFGmemberlist_( attype, groupIndex, 0 );
+                size_t e1 = SF_( attype, memberindex0, 2 );
+                size_t e2 = SF_( attype, memberindex0, 3 );
+                double rc = SF_( attype, memberindex0, 7 );
                 size_t size =
-                    d_SFGmemberlist( attype, groupIndex, maxSFperElem );
+                    SFGmemberlist_( attype, groupIndex, maxSFperElem_ );
 
                 nej = type( j );
-                dxij = ( x( i, 0 ) - x( j, 0 ) ) * CFLENGTH * convLength;
-                dyij = ( x( i, 1 ) - x( j, 1 ) ) * CFLENGTH * convLength;
-                dzij = ( x( i, 2 ) - x( j, 2 ) ) * CFLENGTH * convLength;
+                dxij = ( x( i, 0 ) - x( j, 0 ) ) * CFLENGTH * convLength_;
+                dyij = ( x( i, 1 ) - x( j, 1 ) ) * CFLENGTH * convLength_;
+                dzij = ( x( i, 2 ) - x( j, 2 ) ) * CFLENGTH * convLength_;
                 r2ij = dxij * dxij + dyij * dyij + dzij * dzij;
                 rij = sqrt( r2ij );
                 if ( ( e1 == nej || e2 == nej ) && rij < rc )
                 {
                     // Calculate cutoff function and derivative.
-                    compute_cutoff( cutoffType, pfcij, pdfcij, rij, rc, false );
+                    compute_cutoff( cutoffType_, pfcij, pdfcij, rij, rc,
+                                    false );
 
                     nek = type( k );
 
@@ -951,11 +962,11 @@ void Mode<t_device>::calculateSymmetryFunctionGroups(
                          ( e2 == nej && e1 == nek ) )
                     {
                         dxik =
-                            ( x( i, 0 ) - x( k, 0 ) ) * CFLENGTH * convLength;
+                            ( x( i, 0 ) - x( k, 0 ) ) * CFLENGTH * convLength_;
                         dyik =
-                            ( x( i, 1 ) - x( k, 1 ) ) * CFLENGTH * convLength;
+                            ( x( i, 1 ) - x( k, 1 ) ) * CFLENGTH * convLength_;
                         dzik =
-                            ( x( i, 2 ) - x( k, 2 ) ) * CFLENGTH * convLength;
+                            ( x( i, 2 ) - x( k, 2 ) ) * CFLENGTH * convLength_;
                         r2ik = dxik * dxik + dyik * dyik + dzik * dzik;
                         rik = sqrt( r2ik );
                         if ( rik < rc )
@@ -967,11 +978,11 @@ void Mode<t_device>::calculateSymmetryFunctionGroups(
                             if ( r2jk < rc * rc )
                             {
                                 // Energy calculation.
-                                compute_cutoff( cutoffType, pfcik, pdfcik, rik,
+                                compute_cutoff( cutoffType_, pfcik, pdfcik, rik,
                                                 rc, false );
 
                                 rjk = sqrt( r2jk );
-                                compute_cutoff( cutoffType, pfcjk, pdfcjk, rjk,
+                                compute_cutoff( cutoffType_, pfcjk, pdfcjk, rjk,
                                                 rc, false );
 
                                 double const rinvijik = 1.0 / rij / rik;
@@ -983,17 +994,16 @@ void Mode<t_device>::calculateSymmetryFunctionGroups(
                                        rjks = 0.0;
                                 for ( size_t l = 0; l < size; ++l )
                                 {
-                                    globalIndex =
-                                        d_SF( attype,
-                                              d_SFGmemberlist( attype,
-                                                               groupIndex, l ),
-                                              14 );
-                                    memberindex = d_SFGmemberlist(
-                                        attype, groupIndex, l );
-                                    eta = d_SF( attype, memberindex, 4 );
-                                    lambda = d_SF( attype, memberindex, 5 );
-                                    zeta = d_SF( attype, memberindex, 6 );
-                                    rs = d_SF( attype, memberindex, 8 );
+                                    globalIndex = SF_(
+                                        attype,
+                                        SFGmemberlist_( attype, groupIndex, l ),
+                                        14 );
+                                    memberindex =
+                                        SFGmemberlist_( attype, groupIndex, l );
+                                    eta = SF_( attype, memberindex, 4 );
+                                    lambda = SF_( attype, memberindex, 5 );
+                                    zeta = SF_( attype, memberindex, 6 );
+                                    rs = SF_( attype, memberindex, 8 );
                                     if ( rs > 0.0 )
                                     {
                                         rijs = rij - rs;
@@ -1035,27 +1045,26 @@ void Mode<t_device>::calculateSymmetryFunctionGroups(
         int memberindex0;
         int memberindex, globalIndex;
         double raw_value = 0.0;
-        for ( int groupIndex = 0; groupIndex < numSFGperElem( attype );
+        for ( int groupIndex = 0; groupIndex < numSFGperElem_( attype );
               ++groupIndex )
         {
-            memberindex0 = d_SFGmemberlist( attype, groupIndex, 0 );
+            memberindex0 = SFGmemberlist_( attype, groupIndex, 0 );
 
-            size_t size = d_SFGmemberlist( attype, groupIndex, maxSFperElem );
+            size_t size = SFGmemberlist_( attype, groupIndex, maxSFperElem_ );
             for ( size_t k = 0; k < size; ++k )
             {
-                globalIndex = d_SF(
-                    attype, d_SFGmemberlist( attype, groupIndex, k ), 14 );
-                memberindex = d_SFGmemberlist( attype, groupIndex, k );
+                globalIndex =
+                    SF_( attype, SFGmemberlist_( attype, groupIndex, k ), 14 );
+                memberindex = SFGmemberlist_( attype, groupIndex, k );
 
-                if ( d_SF( attype, memberindex0, 1 ) == 2 )
+                if ( SF_( attype, memberindex0, 1 ) == 2 )
                     raw_value = G( i, globalIndex );
-                else if ( d_SF( attype, memberindex0, 1 ) == 3 )
-                    raw_value =
-                        G( i, globalIndex ) *
-                        pow( 2, ( 1 - d_SF( attype, memberindex, 6 ) ) );
+                else if ( SF_( attype, memberindex0, 1 ) == 3 )
+                    raw_value = G( i, globalIndex ) *
+                                pow( 2, ( 1 - SF_( attype, memberindex, 6 ) ) );
 
                 G( i, globalIndex ) =
-                    scale( attype, raw_value, memberindex, d_SFscaling );
+                    scale( attype, raw_value, memberindex, SFscaling_ );
             }
         }
     };
@@ -1072,43 +1081,50 @@ void Mode<t_device>::calculateAtomicNeuralNetworks( t_slice_type type,
                                                     t_slice_dEdG dEdG,
                                                     t_slice_E E, int N_local )
 {
-    NN = d_t_NN( "Mode::NN", N_local, numLayers, maxNeurons );
-    dfdx = d_t_NN( "Mode::dfdx", N_local, numLayers, maxNeurons );
-    inner = d_t_NN( "Mode::inner", N_local, numHiddenLayers, maxNeurons );
-    outer = d_t_NN( "Mode::outer", N_local, numHiddenLayers, maxNeurons );
+    auto NN = d_t_NN( "Mode::NN", N_local, numLayers, maxNeurons );
+    auto dfdx = d_t_NN( "Mode::dfdx", N_local, numLayers, maxNeurons );
+    auto inner = d_t_NN( "Mode::inner", N_local, numHiddenLayers, maxNeurons );
+    auto outer = d_t_NN( "Mode::outer", N_local, numHiddenLayers, maxNeurons );
 
     Kokkos::RangePolicy<exe_space> policy( 0, N_local );
+
+    // Create local copies for lambda
+    auto numSFperElem_ = numSFperElem;
+    auto numNeuronsPerLayer_ = numNeuronsPerLayer;
+    auto numLayers_ = numLayers;
+    auto numHiddenLayers_ = numHiddenLayers;
+    auto AF_ = AF;
 
     auto calc_nn_op = KOKKOS_LAMBDA( const int atomindex )
     {
         int attype = type( atomindex );
         // set input layer of NN
         int layer_0, layer_lminusone;
-        layer_0 = (int)numSFperElem( attype );
+        layer_0 = (int)numSFperElem_( attype );
 
         for ( int k = 0; k < layer_0; ++k )
             NN( atomindex, 0, k ) = G( atomindex, k );
         // forward propagation
-        for ( int l = 1; l < numLayers; l++ )
+        for ( int l = 1; l < numLayers_; l++ )
         {
             if ( l == 1 )
                 layer_lminusone = layer_0;
             else
-                layer_lminusone = numNeuronsPerLayer[l - 1];
+                layer_lminusone = numNeuronsPerLayer_( l - 1 );
             double dtmp;
-            for ( int i = 0; i < numNeuronsPerLayer[l]; i++ )
+            for ( int i = 0; i < numNeuronsPerLayer_( l ); i++ )
             {
                 dtmp = 0.0;
                 for ( int j = 0; j < layer_lminusone; j++ )
                     dtmp += weights( attype, l - 1, i, j ) *
                             NN( atomindex, l - 1, j );
                 dtmp += bias( attype, l - 1, i );
-                if ( AF( l ) == 0 )
+                if ( AF_( l ) == 0 )
                 {
                     NN( atomindex, l, i ) = dtmp;
                     dfdx( atomindex, l, i ) = 1.0;
                 }
-                else if ( AF( l ) == 1 )
+                else if ( AF_( l ) == 1 )
                 {
                     dtmp = tanh( dtmp );
                     NN( atomindex, l, i ) = dtmp;
@@ -1117,34 +1133,34 @@ void Mode<t_device>::calculateAtomicNeuralNetworks( t_slice_type type,
             }
         }
 
-        E( atomindex ) = NN( atomindex, numLayers - 1, 0 );
+        E( atomindex ) = NN( atomindex, numLayers_ - 1, 0 );
 
         // derivative of network w.r.t NN inputs
-        for ( int k = 0; k < numNeuronsPerLayer[0]; k++ )
+        for ( int k = 0; k < numNeuronsPerLayer_( 0 ); k++ )
         {
-            for ( int i = 0; i < numNeuronsPerLayer[1]; i++ )
+            for ( int i = 0; i < numNeuronsPerLayer_( 1 ); i++ )
                 inner( atomindex, 0, i ) =
                     weights( attype, 0, i, k ) * dfdx( atomindex, 1, i );
 
-            for ( int l = 1; l < numHiddenLayers + 1; l++ )
+            for ( int l = 1; l < numHiddenLayers_ + 1; l++ )
             {
-                for ( int i2 = 0; i2 < numNeuronsPerLayer( l + 1 ); i2++ )
+                for ( int i2 = 0; i2 < numNeuronsPerLayer_( l + 1 ); i2++ )
                 {
                     outer( atomindex, l - 1, i2 ) = 0.0;
 
-                    for ( int i1 = 0; i1 < numNeuronsPerLayer( l ); i1++ )
+                    for ( int i1 = 0; i1 < numNeuronsPerLayer_( l ); i1++ )
                         outer( atomindex, l - 1, i2 ) +=
                             weights( attype, l, i2, i1 ) *
                             inner( atomindex, l - 1, i1 );
                     outer( atomindex, l - 1, i2 ) *=
                         dfdx( atomindex, l + 1, i2 );
 
-                    if ( l < numHiddenLayers )
+                    if ( l < numHiddenLayers_ )
                         inner( atomindex, l, i2 ) =
                             outer( atomindex, l - 1, i2 );
                 }
             }
-            dEdG( atomindex, k ) = outer( atomindex, numHiddenLayers - 1, 0 );
+            dEdG( atomindex, k ) = outer( atomindex, numHiddenLayers_ - 1, 0 );
         }
     };
     Kokkos::parallel_for( "Mode::calculateAtomicNeuralNetworks", policy,
@@ -1162,9 +1178,18 @@ void Mode<t_device>::calculateForces( t_slice_x x, t_slice_f f_a,
                                       t_neigh_parallel neigh_op_tag,
                                       t_angle_parallel angle_op_tag )
 {
-    double convForce = convLength / convEnergy;
+    double convForce_ = convLength / convEnergy;
 
     Kokkos::RangePolicy<exe_space> policy( 0, N_local );
+
+    // Create local copies for lambda
+    auto numSFGperElem_ = numSFGperElem;
+    auto SFGmemberlist_ = d_SFGmemberlist;
+    auto SF_ = d_SF;
+    auto SFscaling_ = d_SFscaling;
+    auto maxSFperElem_ = maxSFperElem;
+    auto convLength_ = convLength;
+    auto cutoffType_ = cutoffType;
 
     auto calc_radial_force_op = KOKKOS_LAMBDA( const int i, const int j )
     {
@@ -1177,56 +1202,56 @@ void Mode<t_device>::calculateForces( t_slice_x x, t_slice_f f_a,
 
         int attype = type( i );
 
-        for ( int groupIndex = 0; groupIndex < numSFGperElem( attype );
+        for ( int groupIndex = 0; groupIndex < numSFGperElem_( attype );
               ++groupIndex )
         {
-            if ( d_SF( attype, d_SFGmemberlist( attype, groupIndex, 0 ), 1 ) ==
+            if ( SF_( attype, SFGmemberlist_( attype, groupIndex, 0 ), 1 ) ==
                  2 )
             {
-                size_t memberindex0 = d_SFGmemberlist( attype, groupIndex, 0 );
-                size_t e1 = d_SF( attype, memberindex0, 2 );
-                double rc = d_SF( attype, memberindex0, 7 );
+                size_t memberindex0 = SFGmemberlist_( attype, groupIndex, 0 );
+                size_t e1 = SF_( attype, memberindex0, 2 );
+                double rc = SF_( attype, memberindex0, 7 );
                 size_t size =
-                    d_SFGmemberlist( attype, groupIndex, maxSFperElem );
+                    SFGmemberlist_( attype, groupIndex, maxSFperElem_ );
 
                 size_t nej = type( j );
-                dxij = ( x( i, 0 ) - x( j, 0 ) ) * CFLENGTH * convLength;
-                dyij = ( x( i, 1 ) - x( j, 1 ) ) * CFLENGTH * convLength;
-                dzij = ( x( i, 2 ) - x( j, 2 ) ) * CFLENGTH * convLength;
+                dxij = ( x( i, 0 ) - x( j, 0 ) ) * CFLENGTH * convLength_;
+                dyij = ( x( i, 1 ) - x( j, 1 ) ) * CFLENGTH * convLength_;
+                dzij = ( x( i, 2 ) - x( j, 2 ) ) * CFLENGTH * convLength_;
                 r2ij = dxij * dxij + dyij * dyij + dzij * dzij;
                 rij = sqrt( r2ij );
                 if ( e1 == nej && rij < rc )
                 {
                     // Energy calculation.
                     // Calculate cutoff function and derivative.
-                    compute_cutoff( cutoffType, pfcij, pdfcij, rij, rc, true );
+                    compute_cutoff( cutoffType_, pfcij, pdfcij, rij, rc, true );
                     for ( size_t k = 0; k < size; ++k )
                     {
-                        globalIndex = d_SF(
-                            attype, d_SFGmemberlist( attype, groupIndex, k ),
-                            14 );
-                        memberindex = d_SFGmemberlist( attype, groupIndex, k );
-                        eta = d_SF( attype, memberindex, 4 );
-                        rs = d_SF( attype, memberindex, 8 );
+                        globalIndex =
+                            SF_( attype,
+                                 SFGmemberlist_( attype, groupIndex, k ), 14 );
+                        memberindex = SFGmemberlist_( attype, groupIndex, k );
+                        eta = SF_( attype, memberindex, 4 );
+                        rs = SF_( attype, memberindex, 8 );
                         double pexp = exp( -eta * ( rij - rs ) * ( rij - rs ) );
                         // Force calculation.
                         double const p1 =
-                            d_SFscaling( attype, memberindex, 6 ) *
+                            SFscaling_( attype, memberindex, 6 ) *
                             ( pdfcij - 2.0 * eta * ( rij - rs ) * pfcij ) *
                             pexp / rij;
                         f_a( i, 0 ) -= ( dEdG( i, globalIndex ) *
-                                         ( p1 * dxij ) * CFFORCE * convForce );
+                                         ( p1 * dxij ) * CFFORCE * convForce_ );
                         f_a( i, 1 ) -= ( dEdG( i, globalIndex ) *
-                                         ( p1 * dyij ) * CFFORCE * convForce );
+                                         ( p1 * dyij ) * CFFORCE * convForce_ );
                         f_a( i, 2 ) -= ( dEdG( i, globalIndex ) *
-                                         ( p1 * dzij ) * CFFORCE * convForce );
+                                         ( p1 * dzij ) * CFFORCE * convForce_ );
 
                         f_a( j, 0 ) += ( dEdG( i, globalIndex ) *
-                                         ( p1 * dxij ) * CFFORCE * convForce );
+                                         ( p1 * dxij ) * CFFORCE * convForce_ );
                         f_a( j, 1 ) += ( dEdG( i, globalIndex ) *
-                                         ( p1 * dyij ) * CFFORCE * convForce );
+                                         ( p1 * dyij ) * CFFORCE * convForce_ );
                         f_a( j, 2 ) += ( dEdG( i, globalIndex ) *
-                                         ( p1 * dzij ) * CFFORCE * convForce );
+                                         ( p1 * dzij ) * CFFORCE * convForce_ );
                     }
                 }
             }
@@ -1250,40 +1275,40 @@ void Mode<t_device>::calculateForces( t_slice_x x, t_slice_f f_a,
         int memberindex, globalIndex;
 
         int attype = type( i );
-        for ( int groupIndex = 0; groupIndex < numSFGperElem( attype );
+        for ( int groupIndex = 0; groupIndex < numSFGperElem_( attype );
               ++groupIndex )
         {
-            if ( d_SF( attype, d_SFGmemberlist( attype, groupIndex, 0 ), 1 ) ==
+            if ( SF_( attype, SFGmemberlist_( attype, groupIndex, 0 ), 1 ) ==
                  3 )
             {
-                size_t memberindex0 = d_SFGmemberlist( attype, groupIndex, 0 );
-                size_t e1 = d_SF( attype, memberindex0, 2 );
-                size_t e2 = d_SF( attype, memberindex0, 3 );
-                double rc = d_SF( attype, memberindex0, 7 );
+                size_t memberindex0 = SFGmemberlist_( attype, groupIndex, 0 );
+                size_t e1 = SF_( attype, memberindex0, 2 );
+                size_t e2 = SF_( attype, memberindex0, 3 );
+                double rc = SF_( attype, memberindex0, 7 );
                 size_t size =
-                    d_SFGmemberlist( attype, groupIndex, maxSFperElem );
+                    SFGmemberlist_( attype, groupIndex, maxSFperElem_ );
 
                 nej = type( j );
-                dxij = ( x( i, 0 ) - x( j, 0 ) ) * CFLENGTH * convLength;
-                dyij = ( x( i, 1 ) - x( j, 1 ) ) * CFLENGTH * convLength;
-                dzij = ( x( i, 2 ) - x( j, 2 ) ) * CFLENGTH * convLength;
+                dxij = ( x( i, 0 ) - x( j, 0 ) ) * CFLENGTH * convLength_;
+                dyij = ( x( i, 1 ) - x( j, 1 ) ) * CFLENGTH * convLength_;
+                dzij = ( x( i, 2 ) - x( j, 2 ) ) * CFLENGTH * convLength_;
                 r2ij = dxij * dxij + dyij * dyij + dzij * dzij;
                 rij = sqrt( r2ij );
                 if ( ( e1 == nej || e2 == nej ) && rij < rc )
                 {
                     // Calculate cutoff function and derivative.
-                    compute_cutoff( cutoffType, pfcij, pdfcij, rij, rc, true );
+                    compute_cutoff( cutoffType_, pfcij, pdfcij, rij, rc, true );
 
                     nek = type( k );
                     if ( ( e1 == nej && e2 == nek ) ||
                          ( e2 == nej && e1 == nek ) )
                     {
                         dxik =
-                            ( x( i, 0 ) - x( k, 0 ) ) * CFLENGTH * convLength;
+                            ( x( i, 0 ) - x( k, 0 ) ) * CFLENGTH * convLength_;
                         dyik =
-                            ( x( i, 1 ) - x( k, 1 ) ) * CFLENGTH * convLength;
+                            ( x( i, 1 ) - x( k, 1 ) ) * CFLENGTH * convLength_;
                         dzik =
-                            ( x( i, 2 ) - x( k, 2 ) ) * CFLENGTH * convLength;
+                            ( x( i, 2 ) - x( k, 2 ) ) * CFLENGTH * convLength_;
                         r2ik = dxik * dxik + dyik * dyik + dzik * dzik;
                         rik = sqrt( r2ik );
                         if ( rik < rc )
@@ -1295,11 +1320,11 @@ void Mode<t_device>::calculateForces( t_slice_x x, t_slice_f f_a,
                             if ( r2jk < rc * rc )
                             {
                                 // Energy calculation.
-                                compute_cutoff( cutoffType, pfcik, pdfcik, rik,
+                                compute_cutoff( cutoffType_, pfcik, pdfcik, rik,
                                                 rc, true );
                                 rjk = sqrt( r2jk );
 
-                                compute_cutoff( cutoffType, pfcjk, pdfcjk, rjk,
+                                compute_cutoff( cutoffType_, pfcjk, pdfcjk, rjk,
                                                 rc, true );
 
                                 double const rinvijik = 1.0 / rij / rik;
@@ -1316,17 +1341,16 @@ void Mode<t_device>::calculateForces( t_slice_x x, t_slice_f f_a,
                                        rjks = 0.0;
                                 for ( size_t l = 0; l < size; ++l )
                                 {
-                                    globalIndex =
-                                        d_SF( attype,
-                                              d_SFGmemberlist( attype,
-                                                               groupIndex, l ),
-                                              14 );
-                                    memberindex = d_SFGmemberlist(
-                                        attype, groupIndex, l );
-                                    rs = d_SF( attype, memberindex, 8 );
-                                    eta = d_SF( attype, memberindex, 4 );
-                                    lambda = d_SF( attype, memberindex, 5 );
-                                    zeta = d_SF( attype, memberindex, 6 );
+                                    globalIndex = SF_(
+                                        attype,
+                                        SFGmemberlist_( attype, groupIndex, l ),
+                                        14 );
+                                    memberindex =
+                                        SFGmemberlist_( attype, groupIndex, l );
+                                    rs = SF_( attype, memberindex, 8 );
+                                    eta = SF_( attype, memberindex, 4 );
+                                    lambda = SF_( attype, memberindex, 5 );
+                                    zeta = SF_( attype, memberindex, 6 );
                                     if ( rs > 0.0 )
                                     {
                                         rijs = rij - rs;
@@ -1348,7 +1372,7 @@ void Mode<t_device>::calculateForces( t_slice_x x, t_slice_f f_a,
                                         fg *= pow( plambda, ( zeta - 1.0 ) );
 
                                     fg *= pow( 2, ( 1 - zeta ) ) *
-                                          d_SFscaling( attype, memberindex, 6 );
+                                          SFscaling_( attype, memberindex, 6 );
                                     double const pfczl = pfc * zeta * lambda;
                                     double factorDeriv =
                                         2.0 * eta / zeta / lambda;
@@ -1389,33 +1413,33 @@ void Mode<t_device>::calculateForces( t_slice_x x, t_slice_f f_a,
                                     }
                                     f_a( i, 0 ) -= ( dEdG( i, globalIndex ) *
                                                      ( p1 * dxij + p2 * dxik ) *
-                                                     CFFORCE * convForce );
+                                                     CFFORCE * convForce_ );
                                     f_a( i, 1 ) -= ( dEdG( i, globalIndex ) *
                                                      ( p1 * dyij + p2 * dyik ) *
-                                                     CFFORCE * convForce );
+                                                     CFFORCE * convForce_ );
                                     f_a( i, 2 ) -= ( dEdG( i, globalIndex ) *
                                                      ( p1 * dzij + p2 * dzik ) *
-                                                     CFFORCE * convForce );
+                                                     CFFORCE * convForce_ );
 
                                     f_a( j, 0 ) += ( dEdG( i, globalIndex ) *
                                                      ( p1 * dxij + p3 * dxjk ) *
-                                                     CFFORCE * convForce );
+                                                     CFFORCE * convForce_ );
                                     f_a( j, 1 ) += ( dEdG( i, globalIndex ) *
                                                      ( p1 * dyij + p3 * dyjk ) *
-                                                     CFFORCE * convForce );
+                                                     CFFORCE * convForce_ );
                                     f_a( j, 2 ) += ( dEdG( i, globalIndex ) *
                                                      ( p1 * dzij + p3 * dzjk ) *
-                                                     CFFORCE * convForce );
+                                                     CFFORCE * convForce_ );
 
                                     f_a( k, 0 ) += ( dEdG( i, globalIndex ) *
                                                      ( p2 * dxik - p3 * dxjk ) *
-                                                     CFFORCE * convForce );
+                                                     CFFORCE * convForce_ );
                                     f_a( k, 1 ) += ( dEdG( i, globalIndex ) *
                                                      ( p2 * dyik - p3 * dyjk ) *
-                                                     CFFORCE * convForce );
+                                                     CFFORCE * convForce_ );
                                     f_a( k, 2 ) += ( dEdG( i, globalIndex ) *
                                                      ( p2 * dzik - p3 * dzjk ) *
-                                                     CFFORCE * convForce );
+                                                     CFFORCE * convForce_ );
                                 } // l
                             }     // rjk <= rc
                         }         // rik <= rc

--- a/src/force_types/nnp_mode_impl.h
+++ b/src/force_types/nnp_mode_impl.h
@@ -1094,6 +1094,8 @@ void Mode<t_device>::calculateAtomicNeuralNetworks( t_slice_type type,
     auto numLayers_ = numLayers;
     auto numHiddenLayers_ = numHiddenLayers;
     auto AF_ = AF;
+    auto weights_ = weights;
+    auto bias_ = bias;
 
     auto calc_nn_op = KOKKOS_LAMBDA( const int atomindex )
     {
@@ -1116,9 +1118,9 @@ void Mode<t_device>::calculateAtomicNeuralNetworks( t_slice_type type,
             {
                 dtmp = 0.0;
                 for ( int j = 0; j < layer_lminusone; j++ )
-                    dtmp += weights( attype, l - 1, i, j ) *
+                    dtmp += weights_( attype, l - 1, i, j ) *
                             NN( atomindex, l - 1, j );
-                dtmp += bias( attype, l - 1, i );
+                dtmp += bias_( attype, l - 1, i );
                 if ( AF_( l ) == 0 )
                 {
                     NN( atomindex, l, i ) = dtmp;
@@ -1140,7 +1142,7 @@ void Mode<t_device>::calculateAtomicNeuralNetworks( t_slice_type type,
         {
             for ( int i = 0; i < numNeuronsPerLayer_( 1 ); i++ )
                 inner( atomindex, 0, i ) =
-                    weights( attype, 0, i, k ) * dfdx( atomindex, 1, i );
+                    weights_( attype, 0, i, k ) * dfdx( atomindex, 1, i );
 
             for ( int l = 1; l < numHiddenLayers_ + 1; l++ )
             {
@@ -1150,7 +1152,7 @@ void Mode<t_device>::calculateAtomicNeuralNetworks( t_slice_type type,
 
                     for ( int i1 = 0; i1 < numNeuronsPerLayer_( l ); i1++ )
                         outer( atomindex, l - 1, i2 ) +=
-                            weights( attype, l, i2, i1 ) *
+                            weights_( attype, l, i2, i1 ) *
                             inner( atomindex, l - 1, i1 );
                     outer( atomindex, l - 1, i2 ) *=
                         dfdx( atomindex, l + 1, i2 );

--- a/src/force_types/nnp_mode_impl.h
+++ b/src/force_types/nnp_mode_impl.h
@@ -866,6 +866,7 @@ void Mode<t_device>::calculateSymmetryFunctionGroups(
     auto maxSFperElem_ = maxSFperElem;
     auto convLength_ = convLength;
     auto cutoffType_ = cutoffType;
+    auto cutoffAlpha_ = cutoffAlpha;
 
     auto calc_radial_symm_op = KOKKOS_LAMBDA( const int i, const int j )
     {
@@ -898,8 +899,8 @@ void Mode<t_device>::calculateSymmetryFunctionGroups(
                 rij = sqrt( r2ij );
                 if ( e1 == nej && rij < rc )
                 {
-                    compute_cutoff( cutoffType_, pfcij, pdfcij, rij, rc,
-                                    false );
+                    compute_cutoff( cutoffType_, cutoffAlpha_, pfcij, pdfcij,
+                                    rij, rc, false );
                     for ( size_t k = 0; k < size; ++k )
                     {
                         memberindex = SFGmemberlist_( attype, groupIndex, k );
@@ -953,8 +954,8 @@ void Mode<t_device>::calculateSymmetryFunctionGroups(
                 if ( ( e1 == nej || e2 == nej ) && rij < rc )
                 {
                     // Calculate cutoff function and derivative.
-                    compute_cutoff( cutoffType_, pfcij, pdfcij, rij, rc,
-                                    false );
+                    compute_cutoff( cutoffType_, cutoffAlpha_, pfcij, pdfcij,
+                                    rij, rc, false );
 
                     nek = type( k );
 
@@ -978,12 +979,12 @@ void Mode<t_device>::calculateSymmetryFunctionGroups(
                             if ( r2jk < rc * rc )
                             {
                                 // Energy calculation.
-                                compute_cutoff( cutoffType_, pfcik, pdfcik, rik,
-                                                rc, false );
+                                compute_cutoff( cutoffType_, cutoffAlpha_,
+                                                pfcik, pdfcik, rik, rc, false );
 
                                 rjk = sqrt( r2jk );
-                                compute_cutoff( cutoffType_, pfcjk, pdfcjk, rjk,
-                                                rc, false );
+                                compute_cutoff( cutoffType_, cutoffAlpha_,
+                                                pfcjk, pdfcjk, rjk, rc, false );
 
                                 double const rinvijik = 1.0 / rij / rik;
                                 double const costijk =
@@ -1192,6 +1193,7 @@ void Mode<t_device>::calculateForces( t_slice_x x, t_slice_f f_a,
     auto maxSFperElem_ = maxSFperElem;
     auto convLength_ = convLength;
     auto cutoffType_ = cutoffType;
+    auto cutoffAlpha_ = cutoffAlpha;
 
     auto calc_radial_force_op = KOKKOS_LAMBDA( const int i, const int j )
     {
@@ -1226,7 +1228,8 @@ void Mode<t_device>::calculateForces( t_slice_x x, t_slice_f f_a,
                 {
                     // Energy calculation.
                     // Calculate cutoff function and derivative.
-                    compute_cutoff( cutoffType_, pfcij, pdfcij, rij, rc, true );
+                    compute_cutoff( cutoffType_, cutoffAlpha_, pfcij, pdfcij,
+                                    rij, rc, true );
                     for ( size_t k = 0; k < size; ++k )
                     {
                         globalIndex =
@@ -1299,7 +1302,8 @@ void Mode<t_device>::calculateForces( t_slice_x x, t_slice_f f_a,
                 if ( ( e1 == nej || e2 == nej ) && rij < rc )
                 {
                     // Calculate cutoff function and derivative.
-                    compute_cutoff( cutoffType_, pfcij, pdfcij, rij, rc, true );
+                    compute_cutoff( cutoffType_, cutoffAlpha_, pfcij, pdfcij,
+                                    rij, rc, true );
 
                     nek = type( k );
                     if ( ( e1 == nej && e2 == nek ) ||
@@ -1322,12 +1326,12 @@ void Mode<t_device>::calculateForces( t_slice_x x, t_slice_f f_a,
                             if ( r2jk < rc * rc )
                             {
                                 // Energy calculation.
-                                compute_cutoff( cutoffType_, pfcik, pdfcik, rik,
-                                                rc, true );
+                                compute_cutoff( cutoffType_, cutoffAlpha_,
+                                                pfcik, pdfcik, rik, rc, true );
                                 rjk = sqrt( r2jk );
 
-                                compute_cutoff( cutoffType_, pfcjk, pdfcjk, rjk,
-                                                rc, true );
+                                compute_cutoff( cutoffType_, cutoffAlpha_,
+                                                pfcjk, pdfcjk, rjk, rc, true );
 
                                 double const rinvijik = 1.0 / rij / rik;
                                 double const costijk =


### PR DESCRIPTION
- Fixed mistake in `Element` with the wrong size counter - needs to be the size of the number of groups, currently just radial and angular
- Fixed the same issue as LJ #76, where member variables were used in lambdas

Fixes #77 