### PR TITLE
Fix neighbor allocation guess

### DIFF
--- a/src/neighbor_types/neighbor_verlet.h
+++ b/src/neighbor_types/neighbor_verlet.h
@@ -60,8 +60,11 @@ class NeighborVerlet : public Neighbor<t_System>
 
         list = t_neigh_list( x, 0, N_local, neigh_cut, 1.0, grid_min, grid_max,
                              max_neigh_guess );
-        max_neigh_guess =
-            Cabana::NeighborList<t_neigh_list>::maxNeighbor( list ) * 1.1;
+
+        T_INT current_max =
+            Cabana::NeighborList<t_neigh_list>::maxNeighbor( list );
+        if ( current_max > max_neigh_guess )
+            max_neigh_guess = current_max * 1.1;
     }
 
     t_neigh_list &get() { return list; }


### PR DESCRIPTION
In #78 a pre-allocation guess for the neighbor list was added, but was set up to always increase. For a long enough run the system would always run out of memory. Found by @saakethdesai 

This fixes by only increasing the allocation guess if the max number of neighbors has changed in a given step