### PR TITLE
Use Cajita mesh for MPI decomposition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ find_package(Cabana REQUIRED)
 if( NOT Cabana_ENABLE_MPI )
   message( FATAL_ERROR "Cabana must be compiled with MPI" )
 endif()
+if( NOT Cabana_ENABLE_CAJITA )
+  message( FATAL_ERROR "Cabana must be compiled with Cajita" )
+endif()
 
 ##---------------------------------------------------------------------------##
 # Set up optional libraries

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,7 +65,7 @@ target_include_directories(CabanaMD PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
 
 #------------------------------------------------------------
 
-target_link_libraries(CabanaMD Cabana::cabanacore)
+target_link_libraries(CabanaMD Cabana::cabanacore Cabana::Cajita)
 
 if(CabanaMD_ENABLE_NNP AND N2P2_DIR)
   target_include_directories(CabanaMD PUBLIC ${N2P2_DIR}/include)

--- a/src/binning_cabana_impl.h
+++ b/src/binning_cabana_impl.h
@@ -67,9 +67,13 @@ void Binning<t_System>::create_binning( T_X_FLOAT dx_in, T_X_FLOAT dy_in,
         int end =
             do_ghost ? system->N_local + system->N_ghost : system->N_local;
 
-        nbinx = T_INT( system->sub_domain_x / dx_in );
-        nbiny = T_INT( system->sub_domain_y / dy_in );
-        nbinz = T_INT( system->sub_domain_z / dz_in );
+        auto local_mesh_x = system->local_mesh_x;
+        auto local_mesh_y = system->local_mesh_y;
+        auto local_mesh_z = system->local_mesh_z;
+
+        nbinx = T_INT( local_mesh_x / dx_in );
+        nbiny = T_INT( local_mesh_y / dy_in );
+        nbinz = T_INT( local_mesh_z / dz_in );
 
         if ( nbinx == 0 )
             nbinx = 1;
@@ -78,17 +82,17 @@ void Binning<t_System>::create_binning( T_X_FLOAT dx_in, T_X_FLOAT dy_in,
         if ( nbinz == 0 )
             nbinz = 1;
 
-        T_X_FLOAT dx = system->sub_domain_x / nbinx;
-        T_X_FLOAT dy = system->sub_domain_y / nbiny;
-        T_X_FLOAT dz = system->sub_domain_z / nbinz;
+        T_X_FLOAT dx = local_mesh_x / nbinx;
+        T_X_FLOAT dy = local_mesh_y / nbiny;
+        T_X_FLOAT dz = local_mesh_z / nbinz;
 
         T_X_FLOAT eps = dx / 1000;
-        minx = -dx * halo_depth - eps + system->sub_domain_lo_x;
-        maxx = dx * halo_depth + eps + system->sub_domain_hi_x;
-        miny = -dy * halo_depth - eps + system->sub_domain_lo_y;
-        maxy = dy * halo_depth + eps + system->sub_domain_hi_y;
-        minz = -dz * halo_depth - eps + system->sub_domain_lo_z;
-        maxz = dz * halo_depth + eps + system->sub_domain_hi_z;
+        minx = -dx * halo_depth - eps + system->local_mesh_lo_x;
+        maxx = dx * halo_depth + eps + system->local_mesh_hi_x;
+        miny = -dy * halo_depth - eps + system->local_mesh_lo_y;
+        maxy = dy * halo_depth + eps + system->local_mesh_hi_y;
+        minz = -dz * halo_depth - eps + system->local_mesh_lo_z;
+        maxz = dz * halo_depth + eps + system->local_mesh_hi_z;
 
         T_X_FLOAT delta[3] = {dx, dy, dz};
         T_X_FLOAT min[3] = {minx, miny, minz};

--- a/src/cabanamd_impl.h
+++ b/src/cabanamd_impl.h
@@ -199,6 +199,9 @@ void CbnMD<t_System, t_Neighbor>::init( InputCL commandline )
     }
     log( out, "Created atoms." );
 
+    // Set MPI rank neighbors
+    comm->create_domain_decomposition();
+
     // Exchange atoms across MPI ranks
     comm->exchange();
 

--- a/src/comm_mpi.h
+++ b/src/comm_mpi.h
@@ -144,26 +144,26 @@ class Comm
         if ( proc_grid[0] == 1 )
         {
             const T_X_FLOAT x1 = x( i, 0 );
-            if ( x1 > s.domain_x )
-                x( i, 0 ) -= s.domain_x;
+            if ( x1 > s.global_mesh_x )
+                x( i, 0 ) -= s.global_mesh_x;
             if ( x1 < 0 )
-                x( i, 0 ) += s.domain_x;
+                x( i, 0 ) += s.global_mesh_x;
         }
         if ( proc_grid[1] == 1 )
         {
             const T_X_FLOAT y1 = x( i, 1 );
-            if ( y1 > s.domain_y )
-                x( i, 1 ) -= s.domain_y;
+            if ( y1 > s.global_mesh_y )
+                x( i, 1 ) -= s.global_mesh_y;
             if ( y1 < 0 )
-                x( i, 1 ) += s.domain_y;
+                x( i, 1 ) += s.global_mesh_y;
         }
         if ( proc_grid[2] == 1 )
         {
             const T_X_FLOAT z1 = x( i, 2 );
-            if ( z1 > s.domain_z )
-                x( i, 2 ) -= s.domain_z;
+            if ( z1 > s.global_mesh_z )
+                x( i, 2 ) -= s.global_mesh_z;
             if ( z1 < 0 )
-                x( i, 2 ) += s.domain_z;
+                x( i, 2 ) += s.global_mesh_z;
         }
     }
 
@@ -171,67 +171,67 @@ class Comm
     KOKKOS_INLINE_FUNCTION
     void operator()( const TagExchangePack, const T_INT &i ) const
     {
-        if ( ( phase == 0 ) && ( x( i, 0 ) > s.sub_domain_hi_x ) )
+        if ( ( phase == 0 ) && ( x( i, 0 ) > s.local_mesh_hi_x ) )
         {
             const std::size_t pack_idx = pack_count()++;
             if ( pack_idx < pack_ranks_migrate.extent( 0 ) )
             {
                 pack_ranks_migrate( i ) = proc_neighbors_send[phase];
                 if ( proc_pos[0] == proc_grid[0] - 1 )
-                    x( i, 0 ) -= s.domain_x;
+                    x( i, 0 ) -= s.global_mesh_x;
             }
         }
 
-        if ( ( phase == 1 ) && ( x( i, 0 ) < s.sub_domain_lo_x ) )
+        if ( ( phase == 1 ) && ( x( i, 0 ) < s.local_mesh_lo_x ) )
         {
             const std::size_t pack_idx = pack_count()++;
             if ( pack_idx < pack_ranks_migrate.extent( 0 ) )
             {
                 pack_ranks_migrate( i ) = proc_neighbors_send[phase];
                 if ( proc_pos[0] == 0 )
-                    x( i, 0 ) += s.domain_x;
+                    x( i, 0 ) += s.global_mesh_x;
             }
         }
 
-        if ( ( phase == 2 ) && ( x( i, 1 ) > s.sub_domain_hi_y ) )
+        if ( ( phase == 2 ) && ( x( i, 1 ) > s.local_mesh_hi_y ) )
         {
             const std::size_t pack_idx = pack_count()++;
             if ( pack_idx < pack_ranks_migrate.extent( 0 ) )
             {
                 pack_ranks_migrate( i ) = proc_neighbors_send[phase];
                 if ( proc_pos[1] == proc_grid[1] - 1 )
-                    x( i, 1 ) -= s.domain_y;
+                    x( i, 1 ) -= s.global_mesh_y;
             }
         }
-        if ( ( phase == 3 ) && ( x( i, 1 ) < s.sub_domain_lo_y ) )
+        if ( ( phase == 3 ) && ( x( i, 1 ) < s.local_mesh_lo_y ) )
         {
             const std::size_t pack_idx = pack_count()++;
             if ( pack_idx < pack_ranks_migrate.extent( 0 ) )
             {
                 pack_ranks_migrate( i ) = proc_neighbors_send[phase];
                 if ( proc_pos[1] == 0 )
-                    x( i, 1 ) += s.domain_y;
+                    x( i, 1 ) += s.global_mesh_y;
             }
         }
 
-        if ( ( phase == 4 ) && ( x( i, 2 ) > s.sub_domain_hi_z ) )
+        if ( ( phase == 4 ) && ( x( i, 2 ) > s.local_mesh_hi_z ) )
         {
             const std::size_t pack_idx = pack_count()++;
             if ( pack_idx < pack_ranks_migrate.extent( 0 ) )
             {
                 pack_ranks_migrate( i ) = proc_neighbors_send[phase];
                 if ( proc_pos[2] == proc_grid[2] - 1 )
-                    x( i, 2 ) -= s.domain_z;
+                    x( i, 2 ) -= s.global_mesh_z;
             }
         }
-        if ( ( phase == 5 ) && ( x( i, 2 ) < s.sub_domain_lo_z ) )
+        if ( ( phase == 5 ) && ( x( i, 2 ) < s.local_mesh_lo_z ) )
         {
             const std::size_t pack_idx = pack_count()++;
             if ( pack_idx < pack_ranks_migrate.extent( 0 ) )
             {
                 pack_ranks_migrate( i ) = proc_neighbors_send[phase];
                 if ( proc_pos[2] == 0 )
-                    x( i, 2 ) += s.domain_z;
+                    x( i, 2 ) += s.global_mesh_z;
             }
         }
     }
@@ -246,7 +246,7 @@ class Comm
 
         if ( phase == 0 )
         {
-            if ( x( i, 0 ) >= s.sub_domain_hi_x - comm_depth )
+            if ( x( i, 0 ) >= s.local_mesh_hi_x - comm_depth )
             {
                 const std::size_t pack_idx = pack_count()++;
                 if ( pack_idx < pack_indicies.extent( 0 ) )
@@ -258,7 +258,7 @@ class Comm
         }
         if ( phase == 1 )
         {
-            if ( x( i, 0 ) <= s.sub_domain_lo_x + comm_depth )
+            if ( x( i, 0 ) <= s.local_mesh_lo_x + comm_depth )
             {
                 const std::size_t pack_idx = pack_count()++;
                 if ( pack_idx < pack_indicies.extent( 0 ) )
@@ -270,7 +270,7 @@ class Comm
         }
         if ( phase == 2 )
         {
-            if ( x( i, 1 ) >= s.sub_domain_hi_y - comm_depth )
+            if ( x( i, 1 ) >= s.local_mesh_hi_y - comm_depth )
             {
                 const std::size_t pack_idx = pack_count()++;
                 if ( pack_idx < pack_indicies.extent( 0 ) )
@@ -282,7 +282,7 @@ class Comm
         }
         if ( phase == 3 )
         {
-            if ( x( i, 1 ) <= s.sub_domain_lo_y + comm_depth )
+            if ( x( i, 1 ) <= s.local_mesh_lo_y + comm_depth )
             {
                 const std::size_t pack_idx = pack_count()++;
                 if ( pack_idx < pack_indicies.extent( 0 ) )
@@ -294,7 +294,7 @@ class Comm
         }
         if ( phase == 4 )
         {
-            if ( x( i, 2 ) >= s.sub_domain_hi_z - comm_depth )
+            if ( x( i, 2 ) >= s.local_mesh_hi_z - comm_depth )
             {
                 const std::size_t pack_idx = pack_count()++;
                 if ( pack_idx < pack_indicies.extent( 0 ) )
@@ -306,7 +306,7 @@ class Comm
         }
         if ( phase == 5 )
         {
-            if ( x( i, 2 ) <= s.sub_domain_lo_z + comm_depth )
+            if ( x( i, 2 ) <= s.local_mesh_lo_z + comm_depth )
             {
                 const std::size_t pack_idx = pack_count()++;
                 if ( pack_idx < pack_indicies.extent( 0 ) )
@@ -328,27 +328,27 @@ class Comm
         {
         case 0:
             if ( proc_pos[0] == 0 )
-                x( i, 0 ) -= s.domain_x;
+                x( i, 0 ) -= s.global_mesh_x;
             break;
         case 1:
             if ( proc_pos[0] == proc_grid[0] - 1 )
-                x( i, 0 ) += s.domain_x;
+                x( i, 0 ) += s.global_mesh_x;
             break;
         case 2:
             if ( proc_pos[1] == 0 )
-                x( i, 1 ) -= s.domain_y;
+                x( i, 1 ) -= s.global_mesh_y;
             break;
         case 3:
             if ( proc_pos[1] == proc_grid[1] - 1 )
-                x( i, 1 ) += s.domain_y;
+                x( i, 1 ) += s.global_mesh_y;
             break;
         case 4:
             if ( proc_pos[2] == 0 )
-                x( i, 2 ) -= s.domain_z;
+                x( i, 2 ) -= s.global_mesh_z;
             break;
         case 5:
             if ( proc_pos[2] == proc_grid[2] - 1 )
-                x( i, 2 ) += s.domain_z;
+                x( i, 2 ) += s.global_mesh_z;
             break;
         }
     }

--- a/src/inputFile_impl.h
+++ b/src/inputFile_impl.h
@@ -491,27 +491,32 @@ void InputFile<t_System>::create_lattice( Comm<t_System> *comm )
     h_t_mass h_mass = Kokkos::create_mirror_view( s.mass );
     Kokkos::deep_copy( h_mass, s.mass );
 
+    // Create the mesh.
+    T_X_FLOAT max_x = lattice_constant * lattice_nx;
+    T_X_FLOAT max_y = lattice_constant * lattice_ny;
+    T_X_FLOAT max_z = lattice_constant * lattice_nz;
+    std::array<T_X_FLOAT, 3> global_low = {0.0, 0.0, 0.0};
+    std::array<T_X_FLOAT, 3> global_high = {max_x, max_y, max_z};
+    system->create_domain( global_low, global_high );
+    s = *system;
+
+    auto local_mesh_lo_x = s.local_mesh_lo_x;
+    auto local_mesh_lo_y = s.local_mesh_lo_y;
+    auto local_mesh_lo_z = s.local_mesh_lo_z;
+    auto local_mesh_hi_x = s.local_mesh_hi_x;
+    auto local_mesh_hi_y = s.local_mesh_hi_y;
+    auto local_mesh_hi_z = s.local_mesh_hi_z;
+
+    T_INT ix_start = local_mesh_lo_x / s.global_mesh_x * lattice_nx - 0.5;
+    T_INT iy_start = local_mesh_lo_y / s.global_mesh_y * lattice_ny - 0.5;
+    T_INT iz_start = local_mesh_lo_z / s.global_mesh_z * lattice_nz - 0.5;
+    T_INT ix_end = local_mesh_hi_x / s.global_mesh_x * lattice_nx + 0.5;
+    T_INT iy_end = local_mesh_hi_y / s.global_mesh_y * lattice_ny + 0.5;
+    T_INT iz_end = local_mesh_hi_z / s.global_mesh_z * lattice_nz + 0.5;
+
     // Create Simple Cubic Lattice
     if ( lattice_style == LATTICE_SC )
     {
-        system->domain_x = lattice_constant * lattice_nx;
-        system->domain_y = lattice_constant * lattice_ny;
-        system->domain_z = lattice_constant * lattice_nz;
-        system->domain_hi_x = system->domain_x;
-        system->domain_hi_y = system->domain_y;
-        system->domain_hi_z = system->domain_z;
-
-        comm->create_domain_decomposition();
-        s = *system;
-
-        T_INT ix_start = s.sub_domain_lo_x / s.domain_x * lattice_nx - 0.5;
-        T_INT iy_start = s.sub_domain_lo_y / s.domain_y * lattice_ny - 0.5;
-        T_INT iz_start = s.sub_domain_lo_z / s.domain_z * lattice_nz - 0.5;
-
-        T_INT ix_end = s.sub_domain_hi_x / s.domain_x * lattice_nx + 0.5;
-        T_INT iy_end = s.sub_domain_hi_y / s.domain_y * lattice_ny + 0.5;
-        T_INT iz_end = s.sub_domain_hi_z / s.domain_z * lattice_nz + 0.5;
-
         T_INT n = 0;
 
         for ( T_INT iz = iz_start; iz <= iz_end; iz++ )
@@ -523,12 +528,12 @@ void InputFile<t_System>::create_lattice( Comm<t_System> *comm )
                 for ( T_INT ix = ix_start; ix <= ix_end; ix++ )
                 {
                     T_FLOAT xtmp = lattice_constant * ( ix + lattice_offset_x );
-                    if ( ( xtmp >= s.sub_domain_lo_x ) &&
-                         ( ytmp >= s.sub_domain_lo_y ) &&
-                         ( ztmp >= s.sub_domain_lo_z ) &&
-                         ( xtmp < s.sub_domain_hi_x ) &&
-                         ( ytmp < s.sub_domain_hi_y ) &&
-                         ( ztmp < s.sub_domain_hi_z ) )
+                    if ( ( xtmp >= local_mesh_lo_x ) &&
+                         ( ytmp >= local_mesh_lo_y ) &&
+                         ( ztmp >= local_mesh_lo_z ) &&
+                         ( xtmp < local_mesh_hi_x ) &&
+                         ( ytmp < local_mesh_hi_y ) &&
+                         ( ztmp < local_mesh_hi_z ) )
                     {
                         n++;
                     }
@@ -556,12 +561,12 @@ void InputFile<t_System>::create_lattice( Comm<t_System> *comm )
                 for ( T_INT ix = ix_start; ix <= ix_end; ix++ )
                 {
                     T_FLOAT xtmp = lattice_constant * ( ix + lattice_offset_x );
-                    if ( ( xtmp >= s.sub_domain_lo_x ) &&
-                         ( ytmp >= s.sub_domain_lo_y ) &&
-                         ( ztmp >= s.sub_domain_lo_z ) &&
-                         ( xtmp < s.sub_domain_hi_x ) &&
-                         ( ytmp < s.sub_domain_hi_y ) &&
-                         ( ztmp < s.sub_domain_hi_z ) )
+                    if ( ( xtmp >= local_mesh_lo_x ) &&
+                         ( ytmp >= local_mesh_lo_y ) &&
+                         ( ztmp >= local_mesh_lo_z ) &&
+                         ( xtmp < local_mesh_hi_x ) &&
+                         ( ytmp < local_mesh_hi_y ) &&
+                         ( ztmp < local_mesh_hi_z ) )
                     {
                         x( n, 0 ) = xtmp;
                         x( n, 1 ) = ytmp;
@@ -585,16 +590,6 @@ void InputFile<t_System>::create_lattice( Comm<t_System> *comm )
     // Create Face Centered Cubic (FCC) Lattice
     if ( lattice_style == LATTICE_FCC )
     {
-        system->domain_x = lattice_constant * lattice_nx;
-        system->domain_y = lattice_constant * lattice_ny;
-        system->domain_z = lattice_constant * lattice_nz;
-        system->domain_hi_x = system->domain_x;
-        system->domain_hi_y = system->domain_y;
-        system->domain_hi_z = system->domain_z;
-
-        comm->create_domain_decomposition();
-        s = *system;
-
         double basis[4][3];
         basis[0][0] = 0.0;
         basis[0][1] = 0.0;
@@ -616,14 +611,6 @@ void InputFile<t_System>::create_lattice( Comm<t_System> *comm )
             basis[i][2] += lattice_offset_z;
         }
 
-        T_INT ix_start = s.sub_domain_lo_x / s.domain_x * lattice_nx - 0.5;
-        T_INT iy_start = s.sub_domain_lo_y / s.domain_y * lattice_ny - 0.5;
-        T_INT iz_start = s.sub_domain_lo_z / s.domain_z * lattice_nz - 0.5;
-
-        T_INT ix_end = s.sub_domain_hi_x / s.domain_x * lattice_nx + 0.5;
-        T_INT iy_end = s.sub_domain_hi_y / s.domain_y * lattice_ny + 0.5;
-        T_INT iz_end = s.sub_domain_hi_z / s.domain_z * lattice_nz + 0.5;
-
         T_INT n = 0;
 
         for ( T_INT iz = iz_start; iz <= iz_end; iz++ )
@@ -640,12 +627,12 @@ void InputFile<t_System>::create_lattice( Comm<t_System> *comm )
                             lattice_constant * ( 1.0 * iy + basis[k][1] );
                         T_FLOAT ztmp =
                             lattice_constant * ( 1.0 * iz + basis[k][2] );
-                        if ( ( xtmp >= s.sub_domain_lo_x ) &&
-                             ( ytmp >= s.sub_domain_lo_y ) &&
-                             ( ztmp >= s.sub_domain_lo_z ) &&
-                             ( xtmp < s.sub_domain_hi_x ) &&
-                             ( ytmp < s.sub_domain_hi_y ) &&
-                             ( ztmp < s.sub_domain_hi_z ) )
+                        if ( ( xtmp >= local_mesh_lo_x ) &&
+                             ( ytmp >= local_mesh_lo_y ) &&
+                             ( ztmp >= local_mesh_lo_z ) &&
+                             ( xtmp < local_mesh_hi_x ) &&
+                             ( ytmp < local_mesh_hi_y ) &&
+                             ( ztmp < local_mesh_hi_z ) )
                         {
                             n++;
                         }
@@ -680,12 +667,12 @@ void InputFile<t_System>::create_lattice( Comm<t_System> *comm )
                             lattice_constant * ( 1.0 * iy + basis[k][1] );
                         T_FLOAT ztmp =
                             lattice_constant * ( 1.0 * iz + basis[k][2] );
-                        if ( ( xtmp >= s.sub_domain_lo_x ) &&
-                             ( ytmp >= s.sub_domain_lo_y ) &&
-                             ( ztmp >= s.sub_domain_lo_z ) &&
-                             ( xtmp < s.sub_domain_hi_x ) &&
-                             ( ytmp < s.sub_domain_hi_y ) &&
-                             ( ztmp < s.sub_domain_hi_z ) )
+                        if ( ( xtmp >= local_mesh_lo_x ) &&
+                             ( ytmp >= local_mesh_lo_y ) &&
+                             ( ztmp >= local_mesh_lo_z ) &&
+                             ( xtmp < local_mesh_hi_x ) &&
+                             ( ytmp < local_mesh_hi_y ) &&
+                             ( ztmp < local_mesh_hi_z ) )
                         {
                             h_x( n, 0 ) = xtmp;
                             h_x( n, 1 ) = ytmp;

--- a/src/neighbor_types/neighbor_verlet.h
+++ b/src/neighbor_types/neighbor_verlet.h
@@ -48,12 +48,10 @@ class NeighborVerlet : public Neighbor<t_System>
     {
         T_INT N_local = system->N_local;
 
-        double grid_min[3] = {system->sub_domain_lo_x - system->sub_domain_x,
-                              system->sub_domain_lo_y - system->sub_domain_y,
-                              system->sub_domain_lo_z - system->sub_domain_z};
-        double grid_max[3] = {system->sub_domain_hi_x + system->sub_domain_x,
-                              system->sub_domain_hi_y + system->sub_domain_y,
-                              system->sub_domain_hi_z + system->sub_domain_z};
+        double grid_min[3] = {system->ghost_mesh_lo_x, system->ghost_mesh_lo_y,
+                              system->ghost_mesh_lo_z};
+        double grid_max[3] = {system->ghost_mesh_hi_x, system->ghost_mesh_hi_y,
+                              system->ghost_mesh_hi_z};
 
         system->slice_x();
         auto x = system->x;

--- a/src/system.h
+++ b/src/system.h
@@ -50,6 +50,7 @@
 #define SYSTEM_H
 
 #include <Cabana_Core.hpp>
+#include <Cajita.hpp>
 #include <Kokkos_Core.hpp>
 
 #include <types.h>
@@ -80,15 +81,21 @@ class SystemCommon
     typedef typename t_mass::HostMirror h_t_mass;
     t_mass mass;
 
-    // Simulation domain
-    T_X_FLOAT domain_x, domain_y, domain_z;
-    T_X_FLOAT domain_lo_x, domain_lo_y, domain_lo_z;
-    T_X_FLOAT domain_hi_x, domain_hi_y, domain_hi_z;
+    // Simulation total domain
+    T_X_FLOAT global_mesh_x, global_mesh_y, global_mesh_z;
 
-    // Simulation sub domain (for example of a single MPI rank)
-    T_X_FLOAT sub_domain_x, sub_domain_y, sub_domain_z;
-    T_X_FLOAT sub_domain_lo_x, sub_domain_lo_y, sub_domain_lo_z;
-    T_X_FLOAT sub_domain_hi_x, sub_domain_hi_y, sub_domain_hi_z;
+    // Simulation sub domain (single MPI rank)
+    T_X_FLOAT local_mesh_x, local_mesh_y, local_mesh_z;
+    T_X_FLOAT local_mesh_lo_x, local_mesh_lo_y, local_mesh_lo_z;
+    T_X_FLOAT local_mesh_hi_x, local_mesh_hi_y, local_mesh_hi_z;
+    T_X_FLOAT ghost_mesh_lo_x, ghost_mesh_lo_y, ghost_mesh_lo_z;
+    T_X_FLOAT ghost_mesh_hi_x, ghost_mesh_hi_y, ghost_mesh_hi_z;
+    std::shared_ptr<Cajita::LocalGrid<Cajita::UniformMesh<T_X_FLOAT>>>
+        local_grid;
+
+    // Only needed for current comm
+    std::array<int, 3> ranks_per_dim;
+    std::array<int, 3> rank_dim_pos;
 
     // Units
     T_FLOAT boltz, mvv2e, dt;
@@ -103,18 +110,67 @@ class SystemCommon
         atom_style = "atomic";
 
         mass = t_mass();
-        domain_x = domain_y = domain_z = 0.0;
-        sub_domain_x = sub_domain_y = sub_domain_z = 0.0;
-        domain_lo_x = domain_lo_y = domain_lo_z = 0.0;
-        domain_hi_x = domain_hi_y = domain_hi_z = 0.0;
-        sub_domain_hi_x = sub_domain_hi_y = sub_domain_hi_z = 0.0;
-        sub_domain_lo_x = sub_domain_lo_y = sub_domain_lo_z = 0.0;
+
+        global_mesh_x = global_mesh_y = global_mesh_z = 0.0;
+        local_mesh_lo_x = local_mesh_lo_y = local_mesh_lo_z = 0.0;
+        local_mesh_hi_x = local_mesh_hi_y = local_mesh_hi_z = 0.0;
+        ghost_mesh_lo_x = ghost_mesh_lo_y = ghost_mesh_lo_z = 0.0;
+        ghost_mesh_hi_x = ghost_mesh_hi_y = ghost_mesh_hi_z = 0.0;
+        local_mesh_x = local_mesh_y = local_mesh_z = 0.0;
+
         mvv2e = boltz = dt = 0.0;
 
         mass = t_mass( "System::mass", ntypes );
     }
 
     ~SystemCommon() {}
+
+    void create_domain( std::array<double, 3> low_corner,
+                        std::array<double, 3> high_corner )
+    {
+        // Create the MPI partitions.
+        Cajita::UniformDimPartitioner partitioner;
+        ranks_per_dim = partitioner.ranksPerDimension( MPI_COMM_WORLD, {} );
+
+        // Create global mesh of MPI partitions.
+        auto global_mesh = Cajita::createUniformGlobalMesh(
+            low_corner, high_corner, ranks_per_dim );
+
+        global_mesh_x = global_mesh->extent( 0 );
+        global_mesh_y = global_mesh->extent( 1 );
+        global_mesh_z = global_mesh->extent( 2 );
+
+        // Create the global grid.
+        std::array<bool, 3> is_periodic = {true, true, true};
+        auto global_grid = Cajita::createGlobalGrid(
+            MPI_COMM_WORLD, global_mesh, is_periodic, partitioner );
+
+        for ( int d = 0; d < 3; d++ )
+        {
+            rank_dim_pos[d] = global_grid->dimBlockId( d );
+        }
+
+        // Create a local mesh
+        int halo_width = 1;
+        local_grid = Cajita::createLocalGrid( global_grid, halo_width );
+        auto local_mesh = Cajita::createLocalMesh<t_device>( *local_grid );
+
+        local_mesh_lo_x = local_mesh.lowCorner( Cajita::Own(), 0 );
+        local_mesh_lo_y = local_mesh.lowCorner( Cajita::Own(), 1 );
+        local_mesh_lo_z = local_mesh.lowCorner( Cajita::Own(), 2 );
+        local_mesh_hi_x = local_mesh.highCorner( Cajita::Own(), 0 );
+        local_mesh_hi_y = local_mesh.highCorner( Cajita::Own(), 1 );
+        local_mesh_hi_z = local_mesh.highCorner( Cajita::Own(), 2 );
+        ghost_mesh_lo_x = local_mesh.lowCorner( Cajita::Ghost(), 0 );
+        ghost_mesh_lo_y = local_mesh.lowCorner( Cajita::Ghost(), 1 );
+        ghost_mesh_lo_z = local_mesh.lowCorner( Cajita::Ghost(), 2 );
+        ghost_mesh_hi_x = local_mesh.highCorner( Cajita::Ghost(), 0 );
+        ghost_mesh_hi_y = local_mesh.highCorner( Cajita::Ghost(), 1 );
+        ghost_mesh_hi_z = local_mesh.highCorner( Cajita::Ghost(), 2 );
+        local_mesh_x = local_mesh.extent( Cajita::Own(), 0 );
+        local_mesh_y = local_mesh.extent( Cajita::Own(), 1 );
+        local_mesh_z = local_mesh.extent( Cajita::Own(), 2 );
+    }
 
     void slice_all()
     {

--- a/unit_test/tstIntegrator.hpp
+++ b/unit_test/tstIntegrator.hpp
@@ -41,10 +41,8 @@ t_System createParticles( const int num_particle, const int num_ghost,
     system.N_local = num_particle - num_ghost;
     system.N_ghost = num_ghost;
 
-    auto box = box_max - box_min;
-    system.domain_x = system.domain_y = system.domain_z = box;
-    system.domain_lo_x = system.domain_lo_y = system.domain_lo_z = box_min;
-    system.domain_hi_x = system.domain_hi_y = system.domain_hi_z = box_max;
+    system.create_domain( {box_min, box_min, box_min},
+                          {box_max, box_max, box_max} );
 
     system.slice_integrate();
     auto x = system.x;

--- a/unit_test/tstNeighbor.hpp
+++ b/unit_test/tstNeighbor.hpp
@@ -258,14 +258,8 @@ t_System createAtoms( const int num_atom, const int num_ghost,
     system.N_local = num_atom - num_ghost;
     system.N_ghost = num_ghost;
 
-    auto box = box_max - box_min;
-    system.domain_x = system.domain_y = system.domain_z = box;
-    system.domain_lo_x = system.domain_lo_y = system.domain_lo_z = box_min;
-    system.domain_hi_x = system.domain_hi_y = system.domain_hi_z = box_max;
-    system.sub_domain_lo_x = system.sub_domain_lo_y = system.sub_domain_lo_z =
-        box_min;
-    system.sub_domain_hi_x = system.sub_domain_hi_y = system.sub_domain_hi_z =
-        box_max;
+    system.create_domain( {box_min, box_min, box_min},
+                          {box_max, box_max, box_max} );
 
     // Create random atom positions within the box.
     system.slice_x();


### PR DESCRIPTION
Replace MPI decomposition in `Comm` with Cajita. This will enable using Cajita particle-grid functionality in the future and enable flexibility like non-periodic systems, etc.

Closes #57 