### PR TITLE
Simplify mdfactory

### DIFF
--- a/src/mdfactory.h
+++ b/src/mdfactory.h
@@ -21,6 +21,58 @@
 
 class MDfactory
 {
+    template <typename t_sys, typename t_lay>
+    static CabanaMD *createImplVerlet( int half_neigh )
+    {
+        if ( half_neigh )
+        {
+            using t_half = Cabana::HalfNeighborTag;
+            using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
+            return new CbnMD<t_sys, t_neigh>;
+        }
+        else
+        {
+            using t_full = Cabana::FullNeighborTag;
+            using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
+            return new CbnMD<t_sys, t_neigh>;
+        }
+    }
+#ifdef Cabana_ENABLE_ARBORX
+    template <typename t_sys, typename t_lay>
+    static CabanaMD *createImplTree( int half_neigh )
+    {
+        if ( half_neigh )
+        {
+            using t_half = Cabana::HalfNeighborTag;
+            using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
+            return new CbnMD<t_sys, t_neigh>;
+        }
+        else
+        {
+            using t_full = Cabana::FullNeighborTag;
+            using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
+            return new CbnMD<t_sys, t_neigh>;
+        }
+    }
+#endif
+    template <typename t_sys>
+    static CabanaMD *createImplSystem( int neigh, int half_neigh )
+    {
+        if ( neigh == NEIGH_VERLET_2D )
+            return createImplVerlet<t_sys, Cabana::VerletLayout2D>(
+                half_neigh );
+        else if ( neigh == NEIGH_VERLET_CSR )
+            return createImplVerlet<t_sys, Cabana::VerletLayoutCSR>(
+                half_neigh );
+#ifdef Cabana_ENABLE_ARBORX
+        else if ( neigh == NEIGH_TREE_2D )
+            return createImplTree<t_sys, Cabana::VerletLayout2D>( half_neigh );
+        else if ( neigh == NEIGH_TREE_CSR )
+            return createImplTree<t_sys, Cabana::VerletLayoutCSR>( half_neigh );
+#endif // ArborX
+        return nullptr;
+    }
+
     template <typename t_device>
     static CabanaMD *createImpl( InputCL commandline )
     {
@@ -30,215 +82,14 @@ class MDfactory
             commandline.force_iteration_type == FORCE_ITER_NEIGH_HALF;
 
         if ( layout == AOSOA_1 )
-        {
-            using t_sys = System<t_device, AoSoA1>;
-            if ( neigh == NEIGH_VERLET_2D )
-            {
-                using t_lay = Cabana::VerletLayout2D;
-                if ( half_neigh )
-                {
-                    using t_half = Cabana::HalfNeighborTag;
-                    using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-                else
-                {
-                    using t_full = Cabana::FullNeighborTag;
-                    using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-            }
-            else if ( neigh == NEIGH_VERLET_CSR )
-            {
-                using t_lay = Cabana::VerletLayoutCSR;
-                if ( half_neigh )
-                {
-                    using t_half = Cabana::HalfNeighborTag;
-                    using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-                else
-                {
-                    using t_full = Cabana::FullNeighborTag;
-                    using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-            }
-#ifdef Cabana_ENABLE_ARBORX
-            else if ( neigh == NEIGH_TREE_2D )
-            {
-                using t_lay = Cabana::VerletLayout2D;
-                if ( half_neigh )
-                {
-                    using t_half = Cabana::HalfNeighborTag;
-                    using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-                else
-                {
-                    using t_full = Cabana::FullNeighborTag;
-                    using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-            }
-            else if ( neigh == NEIGH_TREE_CSR )
-            {
-                using t_lay = Cabana::VerletLayoutCSR;
-                if ( half_neigh )
-                {
-                    using t_half = Cabana::HalfNeighborTag;
-                    using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-                else
-                {
-                    using t_full = Cabana::FullNeighborTag;
-                    using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-            }
-#endif // ArborX
-        }
+            return createImplSystem<System<t_device, AoSoA1>>( neigh,
+                                                               half_neigh );
         else if ( layout == AOSOA_2 )
-        {
-            using t_sys = System<t_device, AoSoA2>;
-            if ( neigh == NEIGH_VERLET_2D )
-            {
-                using t_lay = Cabana::VerletLayout2D;
-                if ( half_neigh )
-                {
-                    using t_half = Cabana::HalfNeighborTag;
-                    using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-                else
-                {
-                    using t_full = Cabana::FullNeighborTag;
-                    using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-            }
-            else if ( neigh == NEIGH_VERLET_CSR )
-            {
-                using t_lay = Cabana::VerletLayoutCSR;
-                if ( half_neigh )
-                {
-                    using t_half = Cabana::HalfNeighborTag;
-                    using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-                else
-                {
-                    using t_full = Cabana::FullNeighborTag;
-                    using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-            }
-#ifdef Cabana_ENABLE_ARBORX
-            else if ( neigh == NEIGH_TREE_2D )
-            {
-                using t_lay = Cabana::VerletLayout2D;
-                if ( half_neigh )
-                {
-                    using t_half = Cabana::HalfNeighborTag;
-                    using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-                else
-                {
-                    using t_full = Cabana::FullNeighborTag;
-                    using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-            }
-            else if ( neigh == NEIGH_TREE_CSR )
-            {
-                using t_lay = Cabana::VerletLayoutCSR;
-                if ( half_neigh )
-                {
-                    using t_half = Cabana::HalfNeighborTag;
-                    using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-                else
-                {
-                    using t_full = Cabana::FullNeighborTag;
-                    using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-            }
-#endif // ArborX
-        }
+            return createImplSystem<System<t_device, AoSoA2>>( neigh,
+                                                               half_neigh );
         else if ( layout == AOSOA_6 )
-        {
-            using t_sys = System<t_device, AoSoA6>;
-            if ( neigh == NEIGH_VERLET_2D )
-            {
-                using t_lay = Cabana::VerletLayout2D;
-                if ( half_neigh )
-                {
-                    using t_half = Cabana::HalfNeighborTag;
-                    using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-                else
-                {
-                    using t_full = Cabana::FullNeighborTag;
-                    using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-            }
-            else if ( neigh == NEIGH_VERLET_CSR )
-            {
-                using t_lay = Cabana::VerletLayoutCSR;
-                if ( half_neigh )
-                {
-                    using t_half = Cabana::HalfNeighborTag;
-                    using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-                else
-                {
-                    using t_full = Cabana::FullNeighborTag;
-                    using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-            }
-#ifdef Cabana_ENABLE_ARBORX
-            else if ( neigh == NEIGH_TREE_2D )
-            {
-                using t_lay = Cabana::VerletLayout2D;
-                if ( half_neigh )
-                {
-                    using t_half = Cabana::HalfNeighborTag;
-                    using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-                else
-                {
-                    using t_full = Cabana::FullNeighborTag;
-                    using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-            }
-            else if ( neigh == NEIGH_TREE_CSR )
-            {
-                using t_lay = Cabana::VerletLayoutCSR;
-                if ( half_neigh )
-                {
-                    using t_half = Cabana::HalfNeighborTag;
-                    using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-                else
-                {
-                    using t_full = Cabana::FullNeighborTag;
-                    using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                    return new CbnMD<t_sys, t_neigh>;
-                }
-            }
-#endif // ArborX
-        }
+            return createImplSystem<System<t_device, AoSoA6>>( neigh,
+                                                               half_neigh );
         return nullptr;
     }
 
@@ -254,7 +105,7 @@ class MDfactory
 #ifndef KOKKOS_ENABLE_CUDA
             throw std::runtime_error(
                 "CabanaMD not compiled with Kokkos::Cuda" );
-#endif // Cuda
+#endif
         }
         if ( device == DEFAULT )
         {

--- a/src/mdfactory.h
+++ b/src/mdfactory.h
@@ -21,14 +21,231 @@
 
 class MDfactory
 {
-  public:
-    static CabanaMD *create( InputCL commandline )
+    template <typename t_device>
+    static CabanaMD *createImpl( InputCL commandline )
     {
-        int device = commandline.device_type;
         int layout = commandline.layout_type;
         int neigh = commandline.neighbor_type;
         bool half_neigh =
             commandline.force_iteration_type == FORCE_ITER_NEIGH_HALF;
+
+        if ( layout == AOSOA_1 )
+        {
+            using t_sys = System<t_device, AoSoA1>;
+            if ( neigh == NEIGH_VERLET_2D )
+            {
+                using t_lay = Cabana::VerletLayout2D;
+                if ( half_neigh )
+                {
+                    using t_half = Cabana::HalfNeighborTag;
+                    using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+                else
+                {
+                    using t_full = Cabana::FullNeighborTag;
+                    using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+            }
+            else if ( neigh == NEIGH_VERLET_CSR )
+            {
+                using t_lay = Cabana::VerletLayoutCSR;
+                if ( half_neigh )
+                {
+                    using t_half = Cabana::HalfNeighborTag;
+                    using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+                else
+                {
+                    using t_full = Cabana::FullNeighborTag;
+                    using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+            }
+#ifdef Cabana_ENABLE_ARBORX
+            else if ( neigh == NEIGH_TREE_2D )
+            {
+                using t_lay = Cabana::VerletLayout2D;
+                if ( half_neigh )
+                {
+                    using t_half = Cabana::HalfNeighborTag;
+                    using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+                else
+                {
+                    using t_full = Cabana::FullNeighborTag;
+                    using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+            }
+            else if ( neigh == NEIGH_TREE_CSR )
+            {
+                using t_lay = Cabana::VerletLayoutCSR;
+                if ( half_neigh )
+                {
+                    using t_half = Cabana::HalfNeighborTag;
+                    using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+                else
+                {
+                    using t_full = Cabana::FullNeighborTag;
+                    using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+            }
+#endif // ArborX
+        }
+        else if ( layout == AOSOA_2 )
+        {
+            using t_sys = System<t_device, AoSoA2>;
+            if ( neigh == NEIGH_VERLET_2D )
+            {
+                using t_lay = Cabana::VerletLayout2D;
+                if ( half_neigh )
+                {
+                    using t_half = Cabana::HalfNeighborTag;
+                    using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+                else
+                {
+                    using t_full = Cabana::FullNeighborTag;
+                    using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+            }
+            else if ( neigh == NEIGH_VERLET_CSR )
+            {
+                using t_lay = Cabana::VerletLayoutCSR;
+                if ( half_neigh )
+                {
+                    using t_half = Cabana::HalfNeighborTag;
+                    using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+                else
+                {
+                    using t_full = Cabana::FullNeighborTag;
+                    using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+            }
+#ifdef Cabana_ENABLE_ARBORX
+            else if ( neigh == NEIGH_TREE_2D )
+            {
+                using t_lay = Cabana::VerletLayout2D;
+                if ( half_neigh )
+                {
+                    using t_half = Cabana::HalfNeighborTag;
+                    using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+                else
+                {
+                    using t_full = Cabana::FullNeighborTag;
+                    using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+            }
+            else if ( neigh == NEIGH_TREE_CSR )
+            {
+                using t_lay = Cabana::VerletLayoutCSR;
+                if ( half_neigh )
+                {
+                    using t_half = Cabana::HalfNeighborTag;
+                    using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+                else
+                {
+                    using t_full = Cabana::FullNeighborTag;
+                    using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+            }
+#endif // ArborX
+        }
+        else if ( layout == AOSOA_6 )
+        {
+            using t_sys = System<t_device, AoSoA6>;
+            if ( neigh == NEIGH_VERLET_2D )
+            {
+                using t_lay = Cabana::VerletLayout2D;
+                if ( half_neigh )
+                {
+                    using t_half = Cabana::HalfNeighborTag;
+                    using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+                else
+                {
+                    using t_full = Cabana::FullNeighborTag;
+                    using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+            }
+            else if ( neigh == NEIGH_VERLET_CSR )
+            {
+                using t_lay = Cabana::VerletLayoutCSR;
+                if ( half_neigh )
+                {
+                    using t_half = Cabana::HalfNeighborTag;
+                    using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+                else
+                {
+                    using t_full = Cabana::FullNeighborTag;
+                    using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+            }
+#ifdef Cabana_ENABLE_ARBORX
+            else if ( neigh == NEIGH_TREE_2D )
+            {
+                using t_lay = Cabana::VerletLayout2D;
+                if ( half_neigh )
+                {
+                    using t_half = Cabana::HalfNeighborTag;
+                    using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+                else
+                {
+                    using t_full = Cabana::FullNeighborTag;
+                    using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+            }
+            else if ( neigh == NEIGH_TREE_CSR )
+            {
+                using t_lay = Cabana::VerletLayoutCSR;
+                if ( half_neigh )
+                {
+                    using t_half = Cabana::HalfNeighborTag;
+                    using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+                else
+                {
+                    using t_full = Cabana::FullNeighborTag;
+                    using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
+                    return new CbnMD<t_sys, t_neigh>;
+                }
+            }
+#endif // ArborX
+        }
+        return nullptr;
+    }
+
+  public:
+    static CabanaMD *create( InputCL commandline )
+    {
+        int device = commandline.device_type;
 
         if ( device == CUDA )
         {
@@ -44,874 +261,40 @@ class MDfactory
             using t_exe = Kokkos::DefaultExecutionSpace;
             using t_mem = typename t_exe::memory_space;
             using t_device = Kokkos::Device<t_exe, t_mem>;
-            if ( layout == AOSOA_1 )
-            {
-                using t_sys = System<t_device, AoSoA1>;
-                if ( neigh == NEIGH_VERLET_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_VERLET_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#ifdef Cabana_ENABLE_ARBORX
-                else if ( neigh == NEIGH_TREE_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_TREE_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#endif // ArborX
-            }
-            else if ( layout == AOSOA_2 )
-            {
-                using t_sys = System<t_device, AoSoA2>;
-                if ( neigh == NEIGH_VERLET_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_VERLET_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#ifdef Cabana_ENABLE_ARBORX
-                else if ( neigh == NEIGH_TREE_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_TREE_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#endif // ArborX
-            }
-            else if ( layout == AOSOA_6 )
-            {
-                using t_sys = System<t_device, AoSoA6>;
-                if ( neigh == NEIGH_VERLET_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_VERLET_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#ifdef Cabana_ENABLE_ARBORX
-                else if ( neigh == NEIGH_TREE_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_TREE_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#endif // ArborX
-            }
+
+            return createImpl<t_device>( commandline );
         }
         if ( device == SERIAL )
         {
 #ifdef KOKKOS_ENABLE_SERIAL
             using t_device = Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace>;
-            if ( layout == AOSOA_1 )
-            {
-                using t_sys = System<t_device, AoSoA1>;
-                if ( neigh == NEIGH_VERLET_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_VERLET_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#ifdef Cabana_ENABLE_ARBORX
-                else if ( neigh == NEIGH_TREE_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_TREE_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#endif // ArborX
-            }
-            else if ( layout == AOSOA_2 )
-            {
-                using t_sys = System<t_device, AoSoA2>;
-                if ( neigh == NEIGH_VERLET_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_VERLET_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#ifdef Cabana_ENABLE_ARBORX
-                else if ( neigh == NEIGH_TREE_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_TREE_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#endif // ArborX
-            }
-            else if ( layout == AOSOA_6 )
-            {
-                using t_sys = System<t_device, AoSoA6>;
-                if ( neigh == NEIGH_VERLET_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_VERLET_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#ifdef Cabana_ENABLE_ARBORX
-                else if ( neigh == NEIGH_TREE_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_TREE_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#endif // ArborX
-            }
+            return createImpl<t_device>( commandline );
+
 #else
             throw std::runtime_error(
                 "CabanaMD not compiled with Kokkos::Serial" );
-#endif // Serial
+#endif
         }
         else if ( device == OPENMP )
         {
 #ifdef KOKKOS_ENABLE_OPENMP
             using t_device = Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace>;
-            if ( layout == AOSOA_1 )
-            {
-                using t_sys = System<t_device, AoSoA1>;
-                if ( neigh == NEIGH_VERLET_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_VERLET_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#ifdef Cabana_ENABLE_ARBORX
-                else if ( neigh == NEIGH_TREE_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_TREE_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#endif // ArborX
-            }
-            else if ( layout == AOSOA_2 )
-            {
-                using t_sys = System<t_device, AoSoA2>;
-                if ( neigh == NEIGH_VERLET_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_VERLET_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#ifdef Cabana_ENABLE_ARBORX
-                else if ( neigh == NEIGH_TREE_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_TREE_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#endif // ArborX
-            }
-            else if ( layout == AOSOA_6 )
-            {
-                using t_sys = System<t_device, AoSoA6>;
-                if ( neigh == NEIGH_VERLET_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_VERLET_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#ifdef Cabana_ENABLE_ARBORX
-                else if ( neigh == NEIGH_TREE_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_TREE_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#endif // ArborX
-            }
+            return createImpl<t_device>( commandline );
 #else
             throw std::runtime_error(
                 "CabanaMD not compiled with Kokkos::OpenMP" );
-#endif // OpenMP
+#endif
         }
         else if ( device == HIP )
         {
 #ifdef KOKKOS_ENABLE_HIP
             using t_device = Kokkos::Device<Kokkos::Experimental::HIP,
                                             Kokkos::Experimental::HIPSpace>;
-            if ( layout == AOSOA_1 )
-            {
-                using t_sys = System<t_device, AoSoA1>;
-                if ( neigh == NEIGH_VERLET_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_VERLET_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#ifdef Cabana_ENABLE_ARBORX
-                else if ( neigh == NEIGH_TREE_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_TREE_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#endif // ArborX
-            }
-            else if ( layout == AOSOA_2 )
-            {
-                using t_sys = System<t_device, AoSoA2>;
-                if ( neigh == NEIGH_VERLET_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_VERLET_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#ifdef Cabana_ENABLE_ARBORX
-                else if ( neigh == NEIGH_TREE_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_TREE_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#endif // ArborX
-            }
-            else if ( layout == AOSOA_6 )
-            {
-                using t_sys = System<t_device, AoSoA6>;
-                if ( neigh == NEIGH_VERLET_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_VERLET_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborVerlet<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#ifdef Cabana_ENABLE_ARBORX
-                else if ( neigh == NEIGH_TREE_2D )
-                {
-                    using t_lay = Cabana::VerletLayout2D;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-                else if ( neigh == NEIGH_TREE_CSR )
-                {
-                    using t_lay = Cabana::VerletLayoutCSR;
-                    if ( half_neigh )
-                    {
-                        using t_half = Cabana::HalfNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_half, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                    else
-                    {
-                        using t_full = Cabana::FullNeighborTag;
-                        using t_neigh = NeighborTree<t_sys, t_full, t_lay>;
-                        return new CbnMD<t_sys, t_neigh>;
-                    }
-                }
-#endif // ArborX
-            }
+            return createImpl<t_device>( commandline );
 #else
             throw std::runtime_error(
                 "CabanaMD not compiled with Kokkos::Experimental::HIP" );
-#endif // HIP
+#endif
         }
 
         return nullptr;


### PR DESCRIPTION
This stems from my desire to easily enable/disable Kokkos backends in CabanaMD to help with build times. While looking at the file, I decided to reorganize it so that it would require simply commenting few lines of code. 

Disabling backends helps. I had Kokkos compiled with 3 (Serial, OpenMP, Cuda). Disabling Serial and OpenMP by commenting them out in `mdfactory` made the compile+link time go from 12.5min to 
4.5min. While still ridiculous, it's a step towards brighter future (where code is compiled in a few seconds) :)

Of course, it may be better to use CMake to tweak the backend lists. But it is out of scope for me right now.