### PR TITLE
Remove HIP workarounds

### DIFF
--- a/src/cabanamd_impl.h
+++ b/src/cabanamd_impl.h
@@ -79,19 +79,12 @@ void CbnMD<t_System, t_Neighbor>::init( InputCL commandline )
     std::ofstream err( input->error_file, std::ofstream::app );
     log( out, "Read input file." );
 
-    if ( commandline.device_type != HIP )
-    {
-        using exe_space = typename t_System::execution_space;
-        if ( print_rank() )
-            exe_space::print_configuration( out );
-    }
-    else
-    {
-        log( out, "Using Kokkos::Experimental::HIP" );
-    }
+    using exe_space = typename t_System::execution_space;
+    if ( print_rank() )
+        exe_space::print_configuration( out );
 
-    // Check that the requested pair_style was compiled
 #ifndef CabanaMD_ENABLE_NNP
+    // Check that the requested pair_style was compiled
     if ( input->force_type == FORCE_NNP )
     {
         log_err( err, "NNP requested, but not compiled!" );

--- a/src/neighbor_types/neighbor_verlet.h
+++ b/src/neighbor_types/neighbor_verlet.h
@@ -27,11 +27,7 @@ class NeighborVerlet : public Neighbor<t_System>
     bool half_neigh;
     T_INT max_neigh_guess;
 
-#ifdef KOKKOS_ENABLE_HIP
-    using t_build = Cabana::TeamOpTag;
-#else
     using t_build = Cabana::TeamVectorOpTag;
-#endif
     using t_neigh_list =
         Cabana::VerletList<memory_space, t_iteration, t_layout, t_build>;
 


### PR DESCRIPTION
With Cabana requiring Kokkos 3.2, these HIP workarounds are no longer necessary. 

Closes #58 