### PR TITLE
NNP get mean energy

### DIFF
--- a/src/force_types/force_nnp_cabana_neigh_impl.h
+++ b/src/force_types/force_nnp_cabana_neigh_impl.h
@@ -122,7 +122,7 @@ T_V_FLOAT ForceNNP<t_System, t_System_NNP, t_Neighbor, t_neigh_parallel,
     // TODO: replace ( 0 ): hardcoded
     system_energy += s->N_local * mode->atomicEnergyOffset( 0 );
     system_energy /= mode->convEnergy;
-    system_energy += s->N * mode->meanEnergy;
+    system_energy += s->N * mode->getMeanEnergy();
     // TODO: generalize (hartree to eV conversion)
     system_energy *= 27.211384021355236;
     step++;


### PR DESCRIPTION
Since Cabana NNP functions were moved to n2p2 and derived from base the class member variable `meanEnergy` was not set correctly - use base class `getMeanEnergy` function instead