### PR TITLE
Fixup make sure Kokkos::finalize gets called before MPI_Finalize

### DIFF
--- a/bin/main.cpp
+++ b/bin/main.cpp
@@ -61,17 +61,19 @@ int main( int argc, char *argv[] )
 
     MPI_Init( &argc, &argv );
 
-    Kokkos::ScopeGuard scope_guard( argc, argv );
+    {
+        Kokkos::ScopeGuard scope_guard( argc, argv );
 
-    InputCL commandline;
-    commandline.read_args( argc, argv );
+        InputCL commandline;
+        commandline.read_args( argc, argv );
 
-    CabanaMD *cabanamd = MDfactory::create( commandline );
+        CabanaMD *cabanamd = MDfactory::create( commandline );
 
-    cabanamd->init( commandline );
-    cabanamd->run();
+        cabanamd->init( commandline );
+        cabanamd->run();
 
-    //   cabanamd.check_correctness();
+        //   cabanamd.check_correctness();
+    }
 
     MPI_Finalize();
 }


### PR DESCRIPTION
Without this patch one would get errors when trying to use MPI-aware Kokkos tools such as space-time-stack