### PR TITLE
Remove use of device type in Cabana classes

### DIFF
--- a/src/binning_cabana_impl.h
+++ b/src/binning_cabana_impl.h
@@ -101,9 +101,9 @@ void Binning<t_System>::create_binning( T_X_FLOAT dx_in, T_X_FLOAT dy_in,
         system->slice_x();
         auto x = system->x;
 
-        using device_type = typename t_System::device_type;
-        Cabana::LinkedCellList<device_type> cell_list( x, begin, end, delta,
-                                                       min, max );
+        using memory_space = typename t_System::memory_space;
+        Cabana::LinkedCellList<memory_space> cell_list( x, begin, end, delta,
+                                                        min, max );
 
         if ( sort )
         {

--- a/src/cabanamd_impl.h
+++ b/src/cabanamd_impl.h
@@ -135,39 +135,33 @@ void CbnMD<t_System, t_Neighbor>::init( InputCL commandline )
                           "for the neural network potential." );
         else
         {
-            using t_device = typename t_System::device_type;
+            using device_type = typename t_System::device_type;
 #if ( CabanaMD_LAYOUT_NNP == 1 )
             if ( serial_neigh )
-                force =
-                    new ForceNNP<t_System, System_NNP<t_device, 1>, t_Neighbor,
-                                 Cabana::SerialOpTag, Cabana::SerialOpTag>(
-                        system );
+                force = new ForceNNP<t_System, System_NNP<device_type, 1>,
+                                     t_Neighbor, Cabana::SerialOpTag,
+                                     Cabana::SerialOpTag>( system );
             if ( team_neigh )
-                force =
-                    new ForceNNP<t_System, System_NNP<t_device, 1>, t_Neighbor,
-                                 Cabana::TeamOpTag, Cabana::TeamOpTag>(
-                        system );
+                force = new ForceNNP<t_System, System_NNP<device_type, 1>,
+                                     t_Neighbor, Cabana::TeamOpTag,
+                                     Cabana::TeamOpTag>( system );
             if ( vector_angle )
-                force =
-                    new ForceNNP<t_System, System_NNP<t_device, 1>, t_Neighbor,
-                                 Cabana::TeamOpTag, Cabana::TeamVectorOpTag>(
-                        system );
+                force = new ForceNNP<t_System, System_NNP<device_type, 1>,
+                                     t_Neighbor, Cabana::TeamOpTag,
+                                     Cabana::TeamVectorOpTag>( system );
 #elif ( CabanaMD_LAYOUT_NNP == 3 )
             if ( serial_neigh )
-                force =
-                    new ForceNNP<t_System, System_NNP<t_device, 3>, t_Neighbor,
-                                 Cabana::SerialOpTag, Cabana::SerialOpTag>(
-                        system );
+                force = new ForceNNP<t_System, System_NNP<device_type, 3>,
+                                     t_Neighbor, Cabana::SerialOpTag,
+                                     Cabana::SerialOpTag>( system );
             if ( team_neigh )
-                force =
-                    new ForceNNP<t_System, System_NNP<t_device, 3>, t_Neighbor,
-                                 Cabana::TeamOpTag, Cabana::TeamOpTag>(
-                        system );
+                force = new ForceNNP<t_System, System_NNP<device_type, 3>,
+                                     t_Neighbor, Cabana::TeamOpTag,
+                                     Cabana::TeamOpTag>( system );
             if ( vector_angle )
-                force =
-                    new ForceNNP<t_System, System_NNP<t_device, 3>, t_Neighbor,
-                                 Cabana::TeamOpTag, Cabana::TeamVectorOpTag>(
-                        system );
+                force = new ForceNNP<t_System, System_NNP<device_type, 3>,
+                                     t_Neighbor, Cabana::TeamOpTag,
+                                     Cabana::TeamVectorOpTag>( system );
 #endif
         }
     }

--- a/src/comm_mpi.h
+++ b/src/comm_mpi.h
@@ -62,7 +62,7 @@ class Comm
 {
     // Variables Comm doesn't own but requires for computations
 
-    typedef typename t_System::device_type device_type;
+    using memory_space = typename t_System::memory_space;
 
     T_INT N_local;
     T_INT N_ghost;
@@ -85,20 +85,20 @@ class Comm
     int proc_size;              // Number of processes
     int max_local;
 
-    Kokkos::View<int, Kokkos::LayoutRight, device_type,
+    Kokkos::View<int, Kokkos::LayoutRight, memory_space,
                  Kokkos::MemoryTraits<Kokkos::Atomic>>
         pack_count;
 
-    Kokkos::View<T_INT **, Kokkos::LayoutRight, device_type> pack_indicies_all;
-    Kokkos::View<T_INT *, Kokkos::LayoutRight, device_type> pack_indicies;
-    Kokkos::View<T_INT **, Kokkos::LayoutRight, device_type> pack_ranks_all;
-    Kokkos::View<T_INT *, Kokkos::LayoutRight, device_type> pack_ranks;
-    Kokkos::View<T_INT *, Kokkos::LayoutRight, device_type>
+    Kokkos::View<T_INT **, Kokkos::LayoutRight, memory_space> pack_indicies_all;
+    Kokkos::View<T_INT *, Kokkos::LayoutRight, memory_space> pack_indicies;
+    Kokkos::View<T_INT **, Kokkos::LayoutRight, memory_space> pack_ranks_all;
+    Kokkos::View<T_INT *, Kokkos::LayoutRight, memory_space> pack_ranks;
+    Kokkos::View<T_INT *, Kokkos::LayoutRight, memory_space>
         pack_ranks_migrate_all;
-    Kokkos::View<T_INT *, Kokkos::LayoutRight, device_type> pack_ranks_migrate;
+    Kokkos::View<T_INT *, Kokkos::LayoutRight, memory_space> pack_ranks_migrate;
     std::vector<std::vector<int>> neighbors_halo, neighbors_dist;
 
-    std::vector<std::shared_ptr<Cabana::Halo<device_type>>> halo_all;
+    std::vector<std::shared_ptr<Cabana::Halo<memory_space>>> halo_all;
 
     using exe_space = typename t_System::execution_space;
 

--- a/src/comm_mpi_impl.h
+++ b/src/comm_mpi_impl.h
@@ -61,12 +61,12 @@ Comm<t_System>::Comm( t_System *s, T_X_FLOAT comm_depth_ )
     MPI_Comm_size( MPI_COMM_WORLD, &proc_size );
     MPI_Comm_rank( MPI_COMM_WORLD, &proc_rank );
 
-    pack_count = Kokkos::View<int, Kokkos::LayoutRight, device_type>(
+    pack_count = Kokkos::View<int, Kokkos::LayoutRight, memory_space>(
         "CommMPI::pack_count" );
     pack_indicies_all =
-        Kokkos::View<T_INT **, Kokkos::LayoutRight, device_type>(
+        Kokkos::View<T_INT **, Kokkos::LayoutRight, memory_space>(
             "CommMPI::pack_indicies_all", 6, 200 );
-    pack_ranks_all = Kokkos::View<T_INT **, Kokkos::LayoutRight, device_type>(
+    pack_ranks_all = Kokkos::View<T_INT **, Kokkos::LayoutRight, memory_space>(
         "CommMPI::pack_ranks_all", 6, 200 );
 }
 
@@ -201,10 +201,10 @@ void Comm<t_System>::exchange()
 
     max_local = x.size() * 1.1;
 
-    std::shared_ptr<Cabana::Distributor<device_type>> distributor;
+    std::shared_ptr<Cabana::Distributor<memory_space>> distributor;
 
     pack_ranks_migrate_all =
-        Kokkos::View<T_INT *, Kokkos::LayoutRight, device_type>(
+        Kokkos::View<T_INT *, Kokkos::LayoutRight, memory_space>(
             "pack_ranks_migrate", max_local );
     Kokkos::parallel_for(
         "CommMPI::exchange_self",
@@ -246,7 +246,7 @@ void Comm<t_System>::exchange()
             Kokkos::deep_copy( count, pack_count );
             proc_num_send[phase] = count;
 
-            distributor = std::make_shared<Cabana::Distributor<device_type>>(
+            distributor = std::make_shared<Cabana::Distributor<memory_space>>(
                 MPI_COMM_WORLD, pack_ranks_migrate, neighbors_dist[phase] );
             system->migrate( distributor );
             system->resize(
@@ -328,7 +328,7 @@ void Comm<t_System>::exchange_halo()
         pack_ranks = Kokkos::subview(
             pack_ranks, std::pair<size_t, size_t>( 0, proc_num_send[phase] ) );
 
-        halo_all[phase] = std::make_shared<Cabana::Halo<device_type>>(
+        halo_all[phase] = std::make_shared<Cabana::Halo<memory_space>>(
             MPI_COMM_WORLD, N_local + N_ghost, pack_indicies, pack_ranks,
             neighbors_halo[phase] );
         system->resize( halo_all[phase]->numLocal() +

--- a/src/neighbor_types/neighbor_tree.h
+++ b/src/neighbor_types/neighbor_tree.h
@@ -25,7 +25,6 @@ template <class t_System, class t_iteration>
 class NeighborTree<t_System, t_iteration, Cabana::VerletLayoutCSR>
     : public Neighbor<t_System>
 {
-    using device_type = typename t_System::device_type;
     using memory_space = typename t_System::memory_space;
 
   public:
@@ -73,7 +72,6 @@ template <class t_System, class t_iteration>
 class NeighborTree<t_System, t_iteration, Cabana::VerletLayout2D>
     : public Neighbor<t_System>
 {
-    using device_type = typename t_System::device_type;
     using memory_space = typename t_System::memory_space;
 
   public:

--- a/src/system.h
+++ b/src/system.h
@@ -62,11 +62,11 @@
 #include <stdexcept>
 #include <string>
 
-template <class t_device>
+template <class DeviceType>
 class SystemCommon
 {
   public:
-    using device_type = t_device;
+    using device_type = DeviceType;
     using memory_space = typename device_type::memory_space;
     using execution_space = typename device_type::execution_space;
 
@@ -79,9 +79,8 @@ class SystemCommon
     std::string atom_style;
 
     // Per Type Property
-    // typedef typename t_device::array_layout layout;
-    typedef Kokkos::View<T_V_FLOAT *, t_device> t_mass;
-    typedef Kokkos::View<const T_V_FLOAT *, t_device> t_mass_const;
+    typedef Kokkos::View<T_V_FLOAT *, memory_space> t_mass;
+    typedef Kokkos::View<const T_V_FLOAT *, memory_space> t_mass_const;
     typedef typename t_mass::HostMirror h_t_mass;
     t_mass mass;
 
@@ -241,10 +240,10 @@ class SystemCommon
 
     virtual void init() = 0;
     virtual void resize( T_INT N_new ) = 0;
-    virtual void permute( Cabana::LinkedCellList<t_device> cell_list ) = 0;
-    virtual void
-    migrate( std::shared_ptr<Cabana::Distributor<t_device>> distributor ) = 0;
-    virtual void gather( std::shared_ptr<Cabana::Halo<t_device>> halo ) = 0;
+    virtual void permute( Cabana::LinkedCellList<memory_space> cell_list ) = 0;
+    virtual void migrate(
+        std::shared_ptr<Cabana::Distributor<memory_space>> distributor ) = 0;
+    virtual void gather( std::shared_ptr<Cabana::Halo<memory_space>> halo ) = 0;
     virtual const char *name() { return "SystemNone"; }
 
   private:
@@ -252,7 +251,7 @@ class SystemCommon
     void update_mesh_info()
     {
         auto local_mesh =
-            Cabana::Grid::createLocalMesh<t_device>( *local_grid );
+            Cabana::Grid::createLocalMesh<memory_space>( *local_grid );
 
         local_mesh_lo_x = local_mesh.lowCorner( Cabana::Grid::Own(), 0 );
         local_mesh_lo_y = local_mesh.lowCorner( Cabana::Grid::Own(), 1 );
@@ -272,11 +271,11 @@ class SystemCommon
     }
 };
 
-template <class t_device, int layout>
-class System : public SystemCommon<t_device>
+template <class DeviceType, int layout>
+class System : public SystemCommon<DeviceType>
 {
   public:
-    using SystemCommon<t_device>::SystemCommon;
+    using SystemCommon<DeviceType>::SystemCommon;
 };
 
 #include <modules_system.h>

--- a/src/system_types/system_1aosoa.h
+++ b/src/system_types/system_1aosoa.h
@@ -16,33 +16,37 @@
 
 #include <system.h>
 
-template <class t_device>
-class System<t_device, 1> : public SystemCommon<t_device>
+template <class DeviceType>
+class System<DeviceType, 1> : public SystemCommon<DeviceType>
 {
+  public:
+    using memory_space = typename DeviceType::memory_space;
+    using execution_space = typename DeviceType::execution_space;
+    using SystemCommon<DeviceType>::SystemCommon;
+
+  protected:
     using t_tuple = Cabana::MemberTypes<T_FLOAT[3], T_FLOAT[3], T_FLOAT[3],
                                         T_INT, T_INT, T_FLOAT>;
     using AoSoA_1 =
-        typename Cabana::AoSoA<t_tuple, t_device, CabanaMD_VECTORLENGTH_0>;
+        typename Cabana::AoSoA<t_tuple, memory_space, CabanaMD_VECTORLENGTH_0>;
     AoSoA_1 aosoa_0;
 
-    using SystemCommon<t_device>::N_max;
+    using SystemCommon<DeviceType>::N_max;
 
   public:
-    using SystemCommon<t_device>::SystemCommon;
-
     // Per Particle Property
     using t_x =
-        typename System<t_device, 1>::AoSoA_1::template member_slice_type<0>;
+        typename System<DeviceType, 1>::AoSoA_1::template member_slice_type<0>;
     using t_v =
-        typename System<t_device, 1>::AoSoA_1::template member_slice_type<1>;
+        typename System<DeviceType, 1>::AoSoA_1::template member_slice_type<1>;
     using t_f =
-        typename System<t_device, 1>::AoSoA_1::template member_slice_type<2>;
+        typename System<DeviceType, 1>::AoSoA_1::template member_slice_type<2>;
     using t_type =
-        typename System<t_device, 1>::AoSoA_1::template member_slice_type<3>;
+        typename System<DeviceType, 1>::AoSoA_1::template member_slice_type<3>;
     using t_id =
-        typename System<t_device, 1>::AoSoA_1::template member_slice_type<4>;
+        typename System<DeviceType, 1>::AoSoA_1::template member_slice_type<4>;
     using t_q =
-        typename System<t_device, 1>::AoSoA_1::template member_slice_type<5>;
+        typename System<DeviceType, 1>::AoSoA_1::template member_slice_type<5>;
     t_x x;
     t_v v;
     t_f f;
@@ -75,18 +79,18 @@ class System<t_device, 1> : public SystemCommon<t_device>
     void slice_id() override { id = Cabana::slice<4>( aosoa_0 ); }
     void slice_q() override { q = Cabana::slice<5>( aosoa_0 ); }
 
-    void permute( Cabana::LinkedCellList<t_device> cell_list ) override
+    void permute( Cabana::LinkedCellList<memory_space> cell_list ) override
     {
         Cabana::permute( cell_list, aosoa_0 );
     }
 
-    void migrate(
-        std::shared_ptr<Cabana::Distributor<t_device>> distributor ) override
+    void migrate( std::shared_ptr<Cabana::Distributor<memory_space>>
+                      distributor ) override
     {
         Cabana::migrate( *distributor, aosoa_0 );
     }
 
-    void gather( std::shared_ptr<Cabana::Halo<t_device>> halo ) override
+    void gather( std::shared_ptr<Cabana::Halo<memory_space>> halo ) override
     {
         Cabana::gather( *halo, aosoa_0 );
     }

--- a/src/system_types/system_2aosoa.h
+++ b/src/system_types/system_2aosoa.h
@@ -16,40 +16,42 @@
 
 #include <system.h>
 
-template <class t_device>
-class System<t_device, 2> : public SystemCommon<t_device>
+template <class DeviceType>
+class System<DeviceType, 2> : public SystemCommon<DeviceType>
 {
+  public:
+    using SystemCommon<DeviceType>::SystemCommon;
+
+    using memory_space = typename DeviceType::memory_space;
+    using execution_space = typename DeviceType::execution_space;
+
+  protected:
     using t_tuple_0 = Cabana::MemberTypes<T_FLOAT[3], T_FLOAT[3], T_INT>;
     using t_tuple_1 = Cabana::MemberTypes<T_FLOAT[3], T_INT, T_FLOAT>;
-    using AoSoA_2_0 =
-        typename Cabana::AoSoA<t_tuple_0, t_device, CabanaMD_VECTORLENGTH_0>;
-    using AoSoA_2_1 =
-        typename Cabana::AoSoA<t_tuple_1, t_device, CabanaMD_VECTORLENGTH_1>;
+    using AoSoA_2_0 = typename Cabana::AoSoA<t_tuple_0, memory_space,
+                                             CabanaMD_VECTORLENGTH_0>;
+    using AoSoA_2_1 = typename Cabana::AoSoA<t_tuple_1, memory_space,
+                                             CabanaMD_VECTORLENGTH_1>;
     AoSoA_2_0 aosoa_0;
     AoSoA_2_1 aosoa_1;
 
-    using SystemCommon<t_device>::N_max;
-    // using SystemCommon<t_device>::mass;
+    using SystemCommon<DeviceType>::N_max;
+    // using SystemCommon<DeviceType>::mass;
 
   public:
-    using SystemCommon<t_device>::SystemCommon;
-
-    using memory_space = typename t_device::memory_space;
-    using execution_space = typename t_device::execution_space;
-
     // Per Particle Property
-    using t_x =
-        typename System<t_device, 2>::AoSoA_2_0::template member_slice_type<0>;
-    using t_v =
-        typename System<t_device, 2>::AoSoA_2_1::template member_slice_type<0>;
-    using t_f =
-        typename System<t_device, 2>::AoSoA_2_0::template member_slice_type<1>;
-    using t_type =
-        typename System<t_device, 2>::AoSoA_2_0::template member_slice_type<2>;
-    using t_id =
-        typename System<t_device, 2>::AoSoA_2_1::template member_slice_type<1>;
-    using t_q =
-        typename System<t_device, 2>::AoSoA_2_1::template member_slice_type<2>;
+    using t_x = typename System<DeviceType,
+                                2>::AoSoA_2_0::template member_slice_type<0>;
+    using t_v = typename System<DeviceType,
+                                2>::AoSoA_2_1::template member_slice_type<0>;
+    using t_f = typename System<DeviceType,
+                                2>::AoSoA_2_0::template member_slice_type<1>;
+    using t_type = typename System<DeviceType,
+                                   2>::AoSoA_2_0::template member_slice_type<2>;
+    using t_id = typename System<DeviceType,
+                                 2>::AoSoA_2_1::template member_slice_type<1>;
+    using t_q = typename System<DeviceType,
+                                2>::AoSoA_2_1::template member_slice_type<2>;
     t_x x;
     t_v v;
     t_f f;
@@ -88,20 +90,20 @@ class System<t_device, 2> : public SystemCommon<t_device>
     void slice_id() override { id = Cabana::slice<1>( aosoa_1 ); }
     void slice_q() override { q = Cabana::slice<2>( aosoa_1 ); }
 
-    void permute( Cabana::LinkedCellList<t_device> linkedcell ) override
+    void permute( Cabana::LinkedCellList<memory_space> linkedcell ) override
     {
         Cabana::permute( linkedcell, aosoa_0 );
         Cabana::permute( linkedcell, aosoa_1 );
     }
 
-    void migrate(
-        std::shared_ptr<Cabana::Distributor<t_device>> distributor ) override
+    void migrate( std::shared_ptr<Cabana::Distributor<memory_space>>
+                      distributor ) override
     {
         Cabana::migrate( *distributor, aosoa_0 );
         Cabana::migrate( *distributor, aosoa_1 );
     }
 
-    void gather( std::shared_ptr<Cabana::Halo<t_device>> halo ) override
+    void gather( std::shared_ptr<Cabana::Halo<memory_space>> halo ) override
     {
         Cabana::gather( *halo, aosoa_0 );
         Cabana::gather( *halo, aosoa_1 );

--- a/src/system_types/system_6aosoa.h
+++ b/src/system_types/system_6aosoa.h
@@ -16,24 +16,31 @@
 
 #include <system.h>
 
-template <class t_device>
-class System<t_device, 6> : public SystemCommon<t_device>
+template <class DeviceType>
+class System<DeviceType, 6> : public SystemCommon<DeviceType>
 {
+  public:
+    using SystemCommon<DeviceType>::SystemCommon;
+
+    using memory_space = typename DeviceType::memory_space;
+    using execution_space = typename DeviceType::execution_space;
+
+  protected:
     using t_tuple_x = Cabana::MemberTypes<T_FLOAT[3]>;
     using t_tuple_int = Cabana::MemberTypes<T_INT>;
     using t_tuple_fl = Cabana::MemberTypes<T_FLOAT>;
-    using AoSoA_x =
-        typename Cabana::AoSoA<t_tuple_x, t_device, CabanaMD_VECTORLENGTH_0>;
-    using AoSoA_v =
-        typename Cabana::AoSoA<t_tuple_x, t_device, CabanaMD_VECTORLENGTH_1>;
-    using AoSoA_f =
-        typename Cabana::AoSoA<t_tuple_x, t_device, CabanaMD_VECTORLENGTH_2>;
-    using AoSoA_id =
-        typename Cabana::AoSoA<t_tuple_int, t_device, CabanaMD_VECTORLENGTH_3>;
-    using AoSoA_type =
-        typename Cabana::AoSoA<t_tuple_int, t_device, CabanaMD_VECTORLENGTH_4>;
-    using AoSoA_q =
-        typename Cabana::AoSoA<t_tuple_fl, t_device, CabanaMD_VECTORLENGTH_5>;
+    using AoSoA_x = typename Cabana::AoSoA<t_tuple_x, memory_space,
+                                           CabanaMD_VECTORLENGTH_0>;
+    using AoSoA_v = typename Cabana::AoSoA<t_tuple_x, memory_space,
+                                           CabanaMD_VECTORLENGTH_1>;
+    using AoSoA_f = typename Cabana::AoSoA<t_tuple_x, memory_space,
+                                           CabanaMD_VECTORLENGTH_2>;
+    using AoSoA_id = typename Cabana::AoSoA<t_tuple_int, memory_space,
+                                            CabanaMD_VECTORLENGTH_3>;
+    using AoSoA_type = typename Cabana::AoSoA<t_tuple_int, memory_space,
+                                              CabanaMD_VECTORLENGTH_4>;
+    using AoSoA_q = typename Cabana::AoSoA<t_tuple_fl, memory_space,
+                                           CabanaMD_VECTORLENGTH_5>;
     AoSoA_x aosoa_x;
     AoSoA_v aosoa_v;
     AoSoA_f aosoa_f;
@@ -41,28 +48,24 @@ class System<t_device, 6> : public SystemCommon<t_device>
     AoSoA_type aosoa_type;
     AoSoA_q aosoa_q;
 
-    using SystemCommon<t_device>::N_max;
-    // using SystemCommon<t_device>::mass;
+    using SystemCommon<DeviceType>::N_max;
+    // using SystemCommon<DeviceType>::mass;
 
   public:
-    using SystemCommon<t_device>::SystemCommon;
-
-    using memory_space = typename t_device::memory_space;
-    using execution_space = typename t_device::execution_space;
-
     // Per Particle Property
     using t_x =
-        typename System<t_device, 6>::AoSoA_x::template member_slice_type<0>;
+        typename System<DeviceType, 6>::AoSoA_x::template member_slice_type<0>;
     using t_v =
-        typename System<t_device, 6>::AoSoA_v::template member_slice_type<0>;
+        typename System<DeviceType, 6>::AoSoA_v::template member_slice_type<0>;
     using t_f =
-        typename System<t_device, 6>::AoSoA_f::template member_slice_type<0>;
+        typename System<DeviceType, 6>::AoSoA_f::template member_slice_type<0>;
     using t_type =
-        typename System<t_device, 6>::AoSoA_type::template member_slice_type<0>;
+        typename System<DeviceType,
+                        6>::AoSoA_type::template member_slice_type<0>;
     using t_id =
-        typename System<t_device, 6>::AoSoA_id::template member_slice_type<0>;
+        typename System<DeviceType, 6>::AoSoA_id::template member_slice_type<0>;
     using t_q =
-        typename System<t_device, 6>::AoSoA_q::template member_slice_type<0>;
+        typename System<DeviceType, 6>::AoSoA_q::template member_slice_type<0>;
 
     t_x x;
     t_v v;
@@ -114,7 +117,7 @@ class System<t_device, 6> : public SystemCommon<t_device>
     void slice_id() override { id = Cabana::slice<0>( aosoa_id ); }
     void slice_q() override { q = Cabana::slice<0>( aosoa_q ); }
 
-    void permute( Cabana::LinkedCellList<t_device> cell_list ) override
+    void permute( Cabana::LinkedCellList<memory_space> cell_list ) override
     {
         Cabana::permute( cell_list, aosoa_x );
         Cabana::permute( cell_list, aosoa_v );
@@ -124,8 +127,8 @@ class System<t_device, 6> : public SystemCommon<t_device>
         Cabana::permute( cell_list, aosoa_q );
     }
 
-    void migrate(
-        std::shared_ptr<Cabana::Distributor<t_device>> distributor ) override
+    void migrate( std::shared_ptr<Cabana::Distributor<memory_space>>
+                      distributor ) override
     {
         Cabana::migrate( *distributor, aosoa_x );
         Cabana::migrate( *distributor, aosoa_v );
@@ -135,7 +138,7 @@ class System<t_device, 6> : public SystemCommon<t_device>
         Cabana::migrate( *distributor, aosoa_q );
     }
 
-    void gather( std::shared_ptr<Cabana::Halo<t_device>> halo ) override
+    void gather( std::shared_ptr<Cabana::Halo<memory_space>> halo ) override
     {
         Cabana::gather( *halo, aosoa_x );
         Cabana::gather( *halo, aosoa_v );

--- a/src/system_types/system_nnp.h
+++ b/src/system_types/system_nnp.h
@@ -16,7 +16,7 @@
 
 #include <types.h>
 
-template <class t_device, int layout>
+template <class DeviceType, int layout>
 class System_NNP
 {
 };

--- a/src/system_types/system_nnp_1aosoa.h
+++ b/src/system_types/system_nnp_1aosoa.h
@@ -16,32 +16,36 @@
 
 #include <system_nnp.h>
 
-template <class t_device>
-class System_NNP<t_device, 1>
+template <class DeviceType>
+class System_NNP<DeviceType, 1>
 {
+  public:
+    using memory_space = typename DeviceType::memory_space;
+
+  protected:
     using t_tuple_NNP =
         Cabana::MemberTypes<T_FLOAT[CabanaMD_MAXSYMMFUNC_NNP],
                             T_FLOAT[CabanaMD_MAXSYMMFUNC_NNP], T_FLOAT>;
-    using AoSoA_NNP_1 = typename Cabana::AoSoA<t_tuple_NNP, t_device,
+    using AoSoA_NNP_1 = typename Cabana::AoSoA<t_tuple_NNP, memory_space,
                                                CabanaMD_VECTORLENGTH_NNP_0>;
     AoSoA_NNP_1 aosoa_0;
 
   public:
     using t_G =
-        typename System_NNP<t_device,
+        typename System_NNP<DeviceType,
                             1>::AoSoA_NNP_1::template member_slice_type<0>;
     using t_dEdG =
-        typename System_NNP<t_device,
+        typename System_NNP<DeviceType,
                             1>::AoSoA_NNP_1::template member_slice_type<1>;
     using t_E =
-        typename System_NNP<t_device,
+        typename System_NNP<DeviceType,
                             1>::AoSoA_NNP_1::template member_slice_type<2>;
     t_G G;
     t_dEdG dEdG;
     t_E E;
 
-    System_NNP<t_device, 1>() { AoSoA_NNP_1 aosoa_0( "All", 0 ); }
-    ~System_NNP<t_device, 1>() {}
+    System_NNP<DeviceType, 1>() { AoSoA_NNP_1 aosoa_0( "All", 0 ); }
+    ~System_NNP<DeviceType, 1>() {}
 
     void resize( T_INT N_new ) { aosoa_0.resize( N_new ); }
 

--- a/src/system_types/system_nnp_3aosoa.h
+++ b/src/system_types/system_nnp_3aosoa.h
@@ -16,17 +16,21 @@
 
 #include <system_nnp.h>
 
-template <class t_device>
-class System_NNP<t_device, 3>
+template <class DeviceType>
+class System_NNP<DeviceType, 3>
 {
+  public:
+    using memory_space = typename DeviceType::memory_space;
+
+  protected:
     using t_tuple_NNP_SF =
         Cabana::MemberTypes<T_FLOAT[CabanaMD_MAXSYMMFUNC_NNP]>;
     using t_tuple_NNP_fl = Cabana::MemberTypes<T_FLOAT>;
-    using AoSoA_NNP_G = typename Cabana::AoSoA<t_tuple_NNP_SF, t_device,
+    using AoSoA_NNP_G = typename Cabana::AoSoA<t_tuple_NNP_SF, memory_space,
                                                CabanaMD_VECTORLENGTH_NNP_0>;
-    using AoSoA_NNP_dEdG = typename Cabana::AoSoA<t_tuple_NNP_SF, t_device,
+    using AoSoA_NNP_dEdG = typename Cabana::AoSoA<t_tuple_NNP_SF, memory_space,
                                                   CabanaMD_VECTORLENGTH_NNP_1>;
-    using AoSoA_NNP_E = typename Cabana::AoSoA<t_tuple_NNP_fl, t_device,
+    using AoSoA_NNP_E = typename Cabana::AoSoA<t_tuple_NNP_fl, memory_space,
                                                CabanaMD_VECTORLENGTH_NNP_2>;
     AoSoA_NNP_G aosoa_G;
     AoSoA_NNP_dEdG aosoa_dEdG;
@@ -34,25 +38,25 @@ class System_NNP<t_device, 3>
 
   public:
     using t_G =
-        typename System_NNP<t_device,
+        typename System_NNP<DeviceType,
                             3>::AoSoA_NNP_G::template member_slice_type<0>;
     using t_dEdG =
-        typename System_NNP<t_device,
+        typename System_NNP<DeviceType,
                             3>::AoSoA_NNP_dEdG::template member_slice_type<0>;
     using t_E =
-        typename System_NNP<t_device,
+        typename System_NNP<DeviceType,
                             3>::AoSoA_NNP_E::template member_slice_type<0>;
     t_G G;
     t_dEdG dEdG;
     t_E E;
 
-    System_NNP<t_device, 3>()
+    System_NNP<DeviceType, 3>()
     {
         AoSoA_NNP_G aosoa_G( "G", 0 );
         AoSoA_NNP_dEdG aosoa_dEdG( "dEdG", 0 );
         AoSoA_NNP_E aosoa_E( "E", 0 );
     }
-    ~System_NNP<t_device, 3>() {}
+    ~System_NNP<DeviceType, 3>() {}
 
     void resize( T_INT N_new )
     {


### PR DESCRIPTION
Deprecated and planned for removal. Some type/variable style changes as well 