### PR TITLE
CI: run on ubuntu-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,7 +56,7 @@ jobs:
             vector: '"1;8;32;1;8;32"'
             layout_nnp: '3'
             vector_nnp: '"32;8;1"'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ghcr.io/ecp-copa/ci-containers/${{ matrix.distro }}
     steps:
       - name: Checkout kokkos

--- a/.github/workflows/Weekly.yml
+++ b/.github/workflows/Weekly.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         backend: ["OPENMP", "SERIAL"]
         cmake_build_type: ['Release']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ghcr.io/ecp-copa/ci-containers/ubuntu:latest
     steps:
       - name: Checkout kokkos


### PR DESCRIPTION
20.04 is being retired; avoid having to do this in the future with latest
